### PR TITLE
Added an OpenDSN method to allow for explicit setting of connection properties

### DIFF
--- a/oci8.go
+++ b/oci8.go
@@ -108,6 +108,16 @@ func ParseDSN(dsnString string) (dsn *DSN, err error) {
 				if dsn.Location, err = time.LoadLocation(param[1]); err != nil {
 					return nil, err
 				}
+			case "encoded":
+				if param[1] == "true" {
+					if dsn.Username, err = url.QueryUnescape(dsn.Username); err!=nil {
+						panic(err)
+					}
+					if dsn.Password, _ = url.QueryUnescape(dsn.Password); err!=nil {
+						panic(err)
+					}
+				}
+
 			}
 		}
 	}
@@ -159,11 +169,11 @@ func (c *OCI8Conn) Begin() (driver.Tx, error) {
 }
 
 func (d *OCI8Driver) Open(dsnString string) (connection driver.Conn, err error) {
-	dsn, err := ParseDSN(dsnString); 
+	dsn, err := ParseDSN(dsnString)
 	if err != nil {
 		return nil, err
 	}
-	return d.OpenDSN(dsn);
+	return d.OpenDSN(dsn)
 }
 
 func (d *OCI8Driver) OpenDSN(dsn *DSN) (connection driver.Conn, err error) {


### PR DESCRIPTION
The existing DSN format/parser doesn't allow for more complex usernames and passwords, such as those with embedded @, /, ?, or = symbols.  To allow for this, I added an additional open method where the caller can explicitly pass in the connection information.
