### PR TITLE
Allow URL encoded name/password in DSN connect string, enabled via an option

### DIFF
--- a/oci8.go
+++ b/oci8.go
@@ -108,6 +108,16 @@ func ParseDSN(dsnString string) (dsn *DSN, err error) {
 				if dsn.Location, err = time.LoadLocation(param[1]); err != nil {
 					return nil, err
 				}
+			case "encoded":
+				if param[1] == "true" {
+					if dsn.Username, err = url.QueryUnescape(dsn.Username); err!=nil {
+						panic(err)
+					}
+					if dsn.Password, _ = url.QueryUnescape(dsn.Password); err!=nil {
+						panic(err)
+					}
+				}
+
 			}
 		}
 	}
@@ -159,11 +169,11 @@ func (c *OCI8Conn) Begin() (driver.Tx, error) {
 }
 
 func (d *OCI8Driver) Open(dsnString string) (connection driver.Conn, err error) {
-	dsn, err := ParseDSN(dsnString); 
+	dsn, err := ParseDSN(dsnString)
 	if err != nil {
 		return nil, err
 	}
-	return d.OpenDSN(dsn);
+	return d.OpenDSN(dsn)
 }
 
 func (d *OCI8Driver) OpenDSN(dsn *DSN) (connection driver.Conn, err error) {


### PR DESCRIPTION
In order to pass a username or password in the DSN string that has special characters within it, say an @ symbol, the driver needed some mechanism for encoding/decoding the strings.

I added an option to the DSN driver to enable decoding of the username/password credentials.  To use it, the caller passes encoded=true on the DSN line (e.g. user/pwd@server:port/sid?encoded=true).  When that option is set, and only when it is set, the driver will pass the credentials through the url query parameter decoder before connecting to the Oracle system.
