### PR TITLE
Fix #32

### DIFF
--- a/oci8.go
+++ b/oci8.go
@@ -191,21 +191,24 @@ func (d *OCI8Driver) Open(dsnString string) (connection driver.Conn, err error) 
 		conn.attrs.Set(k, v)
 	}
 
-	rv := C.OCIInitialize(
-		C.OCI_DEFAULT,
-		nil,
-		nil,
-		nil,
+	//	rv := C.OCIInitialize(
+	//		C.OCI_DEFAULT,
+	//		nil,
+	//		nil,
+	//		nil,
+	//		nil)
+	//	if rv == C.OCI_ERROR {
+	//		return nil, ociGetError(conn.err)
+	//	}
+
+	rv := C.OCIEnvInit(
+		(**C.OCIEnv)(unsafe.Pointer(&conn.env)),
+		C.OCI_DEFAULT|C.OCI_THREADED,
+		0,
 		nil)
 	if rv == C.OCI_ERROR {
 		return nil, ociGetError(conn.err)
 	}
-
-	rv = C.OCIEnvInit(
-		(**C.OCIEnv)(unsafe.Pointer(&conn.env)),
-		C.OCI_DEFAULT,
-		0,
-		nil)
 
 	rv = C.OCIHandleAlloc(
 		conn.env,


### PR DESCRIPTION
I think this PR fixed #32 

`OCIInitialize` is deprecated, it's a process level config, multiple invoke will cause crash, for detail see [here](https://docs.oracle.com/database/121/LNOCI/ociaedep001.htm#LNOCI17115)

Create env with OCI_THREADED flag will enable multi-thread feature.