### PR TITLE
Increased NUMBER type buffer size

### DIFF
--- a/oci8.go
+++ b/oci8.go
@@ -969,7 +969,7 @@ func (s *OCI8Stmt) Query(args []driver.Value) (rows driver.Rows, err error) {
 
 		case C.SQLT_NUM:
 			oci8cols[i].kind = C.SQLT_CHR
-			oci8cols[i].size = int(lp)
+			oci8cols[i].size = int(lp * 4)
 			oci8cols[i].pbuf = C.malloc(C.size_t(oci8cols[i].size) + 1)
 
 		case C.SQLT_IBDOUBLE, C.SQLT_IBFLOAT:


### PR DESCRIPTION
I faced the `ORA-01406 fetched column value was truncated` error when querying a column with a NUMBER type with many decimal digits.

That was solved by increasing the size of `lp` variable under `C.SQLT_NUM`.

What do you think?