### PR TITLE
Two-phase commit - XA transaction support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ To enable XA distributed transaction processing for go application servers (e.g.
     $ export CGO_CFLAGS=-DOCI8_ENABLE_XA
     $ go get github.com/mattn/go-oci8
 
+Also when driver is built for XA, you need to pass the "enable_xa=YES" flag to connection string. In this case settings like host, port, username, password and SID are ignored. You can put dummy values there.
     
 You need to put `oci8.pc` like into your `$PKG_CONFIG_PATH`. `oci8.pc` should be like below. This is an example for windows.
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This package can be installed with the go get command:
 
     $ go get github.com/mattn/go-oci8
     
-To enable XA distributed transaction processing for go application servers (e.g. Enduro/X), you need to pass CGO_CFLAGS env variable with "-DOCI8_ENABLE_XA", for example:
+To enable XA distributed transaction processing for go application servers (e.g. endurox-go), you need to pass CGO_CFLAGS env variable with "-DOCI8_ENABLE_XA", for example:
 
     $ export CGO_CFLAGS=-DOCI8_ENABLE_XA
     $ go get github.com/mattn/go-oci8

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ This package can be installed with the go get command:
 
     go get github.com/mattn/go-oci8
 
+To enable XA distributed transaction processing for Go Application Servers (e.g. Enduro/X), you need to pass CGO_CFLAGS env variable with "-DOCI8_ENABLE_XA", for example:
+
+    $ export CGO_CFLAGS=-DOCI8_ENABLE_XA
+    $ go get github.com/mattn/go-oci8
+
+    
 You need to put `oci8.pc` like into your `$PKG_CONFIG_PATH`. `oci8.pc` should be like below. This is an example for windows.
 
 ```

--- a/README.md
+++ b/README.md
@@ -15,12 +15,7 @@ This package can be installed with the go get command:
 
     $ go get github.com/mattn/go-oci8
     
-To enable XA distributed transaction processing, you need to pass CGO_CFLAGS env variable with "-DOCI8_ENABLE_XA", for example:
-
-    $ export CGO_CFLAGS=-DOCI8_ENABLE_XA
-    $ go get github.com/mattn/go-oci8
-
-To enable XA distributed transaction processing for Go Application Servers (e.g. Enduro/X), you need to pass CGO_CFLAGS env variable with "-DOCI8_ENABLE_XA", for example:
+To enable XA distributed transaction processing for go application servers (e.g. Enduro/X), you need to pass CGO_CFLAGS env variable with "-DOCI8_ENABLE_XA", for example:
 
     $ export CGO_CFLAGS=-DOCI8_ENABLE_XA
     $ go get github.com/mattn/go-oci8

--- a/oci8.go
+++ b/oci8.go
@@ -1,4 +1,4 @@
-package oci8
+0package oci8
 
 /*
 #include <oci.h>
@@ -575,7 +575,6 @@ func (d *OCI8Driver) Open(dsnString string) (connection driver.Conn, err error) 
 	if rv := C.WrapxaoEnv((*C.OraText)(unsafe.Pointer(c_dsn))); rv.rv == C.OCI_SUCCESS || rv.rv == C.OCI_SUCCESS_WITH_INFO {
 		conn.env = rv.ptr
 		conn.isXA = true
-		fmt.Printf("Got Env from XA %p\n", conn.env)
 	} else {
 
 		if dsn, err = ParseDSN(dsnString); err != nil {
@@ -596,7 +595,6 @@ func (d *OCI8Driver) Open(dsnString string) (connection driver.Conn, err error) 
 		conn.env,
 		C.OCI_HTYPE_ERROR,
 		0); rv.rv != C.OCI_SUCCESS && rv.rv != C.OCI_SUCCESS_WITH_INFO {
-		fmt.Printf("Error code: %d\n", rv.rv)
 		return nil, errors.New("cant  allocate error handle")
 	} else {
 		conn.err = rv.ptr
@@ -604,7 +602,6 @@ func (d *OCI8Driver) Open(dsnString string) (connection driver.Conn, err error) 
 
 	//Probably use xaoSvcCtx
 	if rv := C.WrapxaoSvcCtx((*C.OraText)(unsafe.Pointer(c_dsn))); rv.rv == C.OCI_SUCCESS || rv.rv == C.OCI_SUCCESS_WITH_INFO {
-		fmt.Print("Got SvcCtx from XA\n")
 		conn.svc = rv.ptr
 	} else {
 

--- a/oci8.go
+++ b/oci8.go
@@ -178,10 +178,12 @@ static ret2ptr
 WrapxaoEnv(OraText *p) {
   ret2ptr vvv = {NULL, NULL, 0};
 
+#ifdef OCI8_ENABLE_XA
   if (!p[0])
   {
   	vvv.ptr = (dvoid *)xaoEnv(NULL);
   }
+#endif
 
   return vvv;
 }
@@ -190,10 +192,13 @@ WrapxaoEnv(OraText *p) {
 static ret2ptr
 WrapxaoSvcCtx(OraText *p) {
   ret2ptr vvv = {NULL, NULL, 0};
+  
+#ifdef OCI8_ENABLE_XA
   if (!p[0])
   {
     vvv.ptr = (dvoid *)xaoSvcCtx(NULL);
   }
+#endif
 
   return vvv;
 }

--- a/oci8.go
+++ b/oci8.go
@@ -4,6 +4,7 @@ package oci8
 #include <oci.h>
 #include <stdlib.h>
 #include <string.h>
+#include <stdint.h>
 
 #cgo pkg-config: oci8
 
@@ -16,7 +17,7 @@ static retErr
 WrapOCIErrorGet(OCIError *err) {
   retErr vvv;
   sb4 errcode;
-  OCIErrorGet(err, 1, NULL, &errcode, vvv.err, sizeof(vvv.err), OCI_HTYPE_ERROR);
+  OCIErrorGet(err, 1, NULL, &errcode, (OraText*) vvv.err, sizeof(vvv.err), OCI_HTYPE_ERROR);
   return vvv;
 }
 
@@ -130,7 +131,7 @@ WrapOCIDescriptorAlloc(dvoid *env, ub4 type, size_t extra) {
     &vvv.ptr,
     type,
     extra,
-    &vvv.extra);
+    ptr);
   return vvv;
 }
 
@@ -173,37 +174,29 @@ WrapOCIEnvCreate(ub4 mode, size_t extra) {
   return vvv;
 }
 
-//mvitolin XA support:
+//madars.vitolins@gmail.com XA support:
 static ret2ptr
-WrapxaoEnv(OraText *p) {
+WrapxaoEnv() {
   ret2ptr vvv = {NULL, NULL, 0};
 
 #ifdef OCI8_ENABLE_XA
-  if (!p[0])
-  {
-  	vvv.ptr = (dvoid *)xaoEnv(NULL);
-  }
+  vvv.ptr = (dvoid *)xaoEnv(NULL);
 #endif
 
   return vvv;
 }
 
-//mvitolin XA support:
+//madars.vitolins@gmail.com XA support:
 static ret2ptr
-WrapxaoSvcCtx(OraText *p) {
+WrapxaoSvcCtx() {
   ret2ptr vvv = {NULL, NULL, 0};
-  
+
 #ifdef OCI8_ENABLE_XA
-  if (!p[0])
-  {
-    vvv.ptr = (dvoid *)xaoSvcCtx(NULL);
-  }
+  vvv.ptr = (dvoid *)xaoSvcCtx(NULL);
 #endif
 
   return vvv;
 }
-
-
 
 static ret1ptr
 WrapOCILogon(OCIEnv *env, OCIError *err, OraText *u, ub4 ulen, OraText *p, ub4 plen, OraText *h, ub4 hlen) {
@@ -325,6 +318,11 @@ WrapOCIAttrSetUb4(dvoid *h, ub4 type, ub4 value, ub4  attrtype, OCIError *err) {
   return OCIAttrSet(h, type, &value, 0, attrtype, err);
 }
 
+typedef struct  {
+	sb2 ind;
+	ub2 rlen;
+} indrlen;
+
 */
 import "C"
 import (
@@ -334,11 +332,7 @@ import (
 	"fmt"
 	"io"
 	"math"
-	"net"
-	"net/url"
-	"os"
 	"regexp"
-	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -347,16 +341,16 @@ import (
 
 const blobBufSize = 4000
 
-var reDSN = regexp.MustCompile(`^([^/]+)/([^@]+)(@[^/]+)?([^?]*)(\?.*)?$`)
-
 type DSN struct {
-	Host            string
-	Port            int
-	Username        string
-	Password        string
-	SID             string
-	Location        *time.Location
-	transactionMode C.ub4
+	Connect              string
+	Username             string
+	Password             string
+	prefetch_rows        uint32
+	prefetch_memory      uint32
+	Location             *time.Location
+	transactionMode      C.ub4
+	enableQMPlaceholders bool
+	enable_xa             bool
 }
 
 func init() {
@@ -367,29 +361,20 @@ type OCI8Driver struct {
 }
 
 type OCI8Conn struct {
-	svc             unsafe.Pointer
-	env             unsafe.Pointer
-	err             unsafe.Pointer
-	attrs           Values
-	location        *time.Location
-	transactionMode C.ub4
-	inTransaction   bool
-	isXA            bool
+	svc                  unsafe.Pointer
+	env                  unsafe.Pointer
+	err                  unsafe.Pointer
+	prefetch_rows        uint32
+	prefetch_memory      uint32
+	location             *time.Location
+	transactionMode      C.ub4
+	inTransaction        bool
+	enableQMPlaceholders bool
+	is_xa            bool
 }
 
 type OCI8Tx struct {
 	c *OCI8Conn
-}
-
-type Values map[string]interface{}
-
-func (vs Values) Set(k string, v interface{}) {
-	vs[k] = v
-}
-
-func (vs Values) Get(k string) (v interface{}) {
-	v, _ = vs[k]
-	return
 }
 
 // ParseDSN parses a DSN used to connect to Oracle
@@ -399,82 +384,47 @@ func (vs Values) Get(k string) (v interface{}) {
 // Currently the parameters supported is:
 // 1 'loc' which
 // sets the timezone to read times in as and to marshal to when writing times to
-// Oracle,
+// Oracle date,
 // 2 'isolation' =READONLY,SERIALIZABLE,DEFAULT
+// 3 'prefetch_rows'
+// 4 'prefetch_memory'
+// 5 'questionph' =YES,NO,TRUE,FALSE enable question-mark placeholders, default to false
+// 6 'enable_xa' =YES,NO,TRUE,FALSE enable XA processing, default to false
 func ParseDSN(dsnString string) (dsn *DSN, err error) {
-	var u *url.URL
 
-	if !strings.HasPrefix(dsnString, "oracle://") {
-		token := reDSN.FindStringSubmatch(dsnString)
-		if len(token) == 6 {
-			host := token[3]
-			path := token[4]
-			if len(host) > 0 {
-				host = host[1:]
-				if path == "" {
-					path = host
-					host = ""
-				}
-			}
-			query := token[5]
-			if len(query) > 0 {
-				query = query[1:]
-			}
-			u = &url.URL{
-				Scheme:   "oracle",
-				User:     url.UserPassword(token[1], token[2]),
-				Host:     host,
-				Path:     path,
-				RawQuery: query,
-			}
-		} else {
-			u = &url.URL{
-				Scheme: "oracle",
-				Opaque: dsnString,
-			}
-		}
-	} else {
-		var err error
-		u, err = url.Parse(dsnString)
+	dsn = &DSN{Location: time.Local}
+
+	if dsnString == "" {
+		return nil, errors.New("empty dsn")
+	}
+
+	const prefix = "oracle://"
+
+	if strings.HasPrefix(dsnString, prefix) {
+		dsnString = dsnString[len(prefix):]
+	}
+
+	authority, dsnString := split(dsnString, "@")
+	if authority != "" {
+		dsn.Username, dsn.Password, err = parseAuthority(authority)
 		if err != nil {
 			return nil, err
 		}
 	}
-	dsn = &DSN{Location: time.Local}
 
-	if u.User != nil {
-		dsn.Username = u.User.Username()
-		password, ok := u.User.Password()
-		if ok {
-			dsn.Password = password
-		} else {
-			if tok := strings.SplitN(dsn.Username, "/", 2); len(tok) >= 2 {
-				dsn.Username = tok[0]
-				dsn.Password = tok[1]
-			}
-		}
-	}
-	host, port, err := net.SplitHostPort(u.Host)
-	if err != nil {
-		if !strings.Contains(err.Error(), "missing port in address") {
-			return nil, fmt.Errorf("Invalid DSN: %q %v", dsnString, err)
-		}
-		host = u.Host
-		port = "1521"
-	}
-	dsn.Host = host
-	nport, err := strconv.Atoi(port)
-	if err != nil {
-		return nil, fmt.Errorf("Invalid DSN: %v", err)
-	}
-	dsn.Port = nport
-	if u.Path != "" {
-		dsn.SID = strings.Trim(u.Path, "/")
-	} else if u.Host != "" {
-		dsn.SID = u.Host
+	host, params := split(dsnString, "?")
+
+	if host, err = unescape(host, encodeHost); err != nil {
+		return nil, err
 	}
 
-	for k, v := range u.Query() {
+	dsn.Connect = host
+	// set safe defaults
+	dsn.prefetch_rows = 10
+	dsn.prefetch_memory = 0
+
+	qp, err := ParseQuery(params)
+	for k, v := range qp {
 		switch k {
 		case "loc":
 			if len(v) > 0 {
@@ -493,8 +443,39 @@ func ParseDSN(dsnString string) (dsn *DSN, err error) {
 			default:
 				return nil, fmt.Errorf("Invalid isolation: %v", v[0])
 			}
+		case "questionph":
+			switch v[0] {
+			case "YES", "TRUE":
+				dsn.enableQMPlaceholders = true
+			case "NO", "FALSE":
+				dsn.enableQMPlaceholders = false
+			default:
+				return nil, fmt.Errorf("Invalid questionpm: %v", v[0])
+			}
+		case "prefetch_rows":
+			z, err := strconv.ParseUint(v[0], 10, 32)
+			if err != nil {
+				return nil, fmt.Errorf("invalid prefetch_rows: %v", v[0])
+			}
+			dsn.prefetch_rows = uint32(z)
+		case "prefetch_memory":
+			z, err := strconv.ParseUint(v[0], 10, 32)
+			if err != nil {
+				return nil, fmt.Errorf("invalid prefetch_memory: %v", v[0])
+			}
+			dsn.prefetch_memory = uint32(z)
+			//default:
+			//log.Println("unused parameter", k)
+		case "enable_xa":
+			switch v[0] {
+			case "YES", "TRUE":
+				dsn.enable_xa = true
+			case "NO", "FALSE":
+				dsn.enable_xa = false
+			default:
+				return nil, fmt.Errorf("Invalid enable_xa: %v", v[0])
+			}
 		}
-
 	}
 	return dsn, nil
 }
@@ -505,7 +486,7 @@ func (tx *OCI8Tx) Commit() error {
 		(*C.OCISvcCtx)(tx.c.svc),
 		(*C.OCIError)(tx.c.err),
 		0); rv != C.OCI_SUCCESS {
-		return ociGetError(tx.c.err)
+		return ociGetError(rv, tx.c.err)
 	}
 	return nil
 }
@@ -516,7 +497,7 @@ func (tx *OCI8Tx) Rollback() error {
 		(*C.OCISvcCtx)(tx.c.svc),
 		(*C.OCIError)(tx.c.err),
 		0); rv != C.OCI_SUCCESS {
-		return ociGetError(tx.c.err)
+		return ociGetError(rv, tx.c.err)
 	}
 	return nil
 }
@@ -539,7 +520,7 @@ func (c *OCI8Conn) Begin() (driver.Tx, error) {
 			0,
 			C.OCI_ATTR_TRANS,
 			(*C.OCIError)(c.err)); rv != C.OCI_SUCCESS {
-			return nil, ociGetError(c.err)
+			return nil, ociGetError(rv, c.err)
 		}
 
 		if rv := C.OCITransStart(
@@ -548,7 +529,7 @@ func (c *OCI8Conn) Begin() (driver.Tx, error) {
 			0,
 			c.transactionMode); // C.OCI_TRANS_SERIALIZABLE C.OCI_TRANS_READWRITE C.OCI_TRANS_READONLY
 		rv != C.OCI_SUCCESS {
-			return nil, ociGetError(c.err)
+			return nil, ociGetError(rv, c.err)
 		}
 	}
 	c.inTransaction = true
@@ -561,31 +542,37 @@ func (d *OCI8Driver) Open(dsnString string) (connection driver.Conn, err error) 
 		dsn  *DSN
 	)
 
-	// set safe defaults
-	conn.attrs = make(Values)
-	conn.attrs.Set("prefetch_rows", 10)
-	conn.attrs.Set("prefetch_memory", int64(0))
-
-	for k, v := range parseEnviron(os.Environ()) {
-		conn.attrs.Set(k, v)
+	if dsn, err = ParseDSN(dsnString); err != nil {
+		return nil, err
 	}
 
-	/* See: https://docs.oracle.com/cd/E11882_01/appdev.112/e41502/adfns_xa.htm#ADFNS1503 */
-
-	c_dsn := C.CString(dsnString)
-	defer C.free(unsafe.Pointer(c_dsn))
-
 	//Firstly try to read env from XA, then fallback to standard connection
-	//It will try to get XA handle, if conn string is empty...
-	if rv := C.WrapxaoEnv((*C.OraText)(unsafe.Pointer(c_dsn))); rv.rv == C.OCI_SUCCESS || rv.rv == C.OCI_SUCCESS_WITH_INFO {
-		conn.env = rv.ptr
-		conn.isXA = true
-	} else {
+	//It will try to get XA handle, if dsn stated so
+	if dsn.enable_xa {
+		rv := C.WrapxaoEnv(); 
+		if rv.ptr != nil {
+		    conn.env = rv.ptr
+		    conn.is_xa = true
 
-		if dsn, err = ParseDSN(dsnString); err != nil {
-			return nil, err
+		    if rv := C.WrapxaoSvcCtx(); rv.ptr != nil {
+				conn.svc = rv.ptr
+		        // We need error handle too for later operations thus allocate it here...
+		        if rv := C.WrapOCIHandleAlloc(
+			        conn.env,
+			        C.OCI_HTYPE_ERROR,
+			        0); rv.rv != C.OCI_SUCCESS {
+			        return nil, errors.New("cant allocate error handle")
+		        } else {
+			        conn.err = rv.ptr
+		        }
+
+		    } else {
+			    return nil, errors.New("can't xaoSvcCtx")
+		    }
 		}
+	}
 
+	if !conn.is_xa {
 		if rv := C.WrapOCIEnvCreate(
 			C.OCI_DEFAULT|C.OCI_THREADED,
 			0); rv.rv != C.OCI_SUCCESS && rv.rv != C.OCI_SUCCESS_WITH_INFO {
@@ -594,56 +581,43 @@ func (d *OCI8Driver) Open(dsnString string) (connection driver.Conn, err error) 
 		} else {
 			conn.env = rv.ptr
 		}
-	}
 
-	if rv := C.WrapOCIHandleAlloc(
-		conn.env,
-		C.OCI_HTYPE_ERROR,
-		0); rv.rv != C.OCI_SUCCESS && rv.rv != C.OCI_SUCCESS_WITH_INFO {
-		return nil, errors.New("cant  allocate error handle")
-	} else {
-		conn.err = rv.ptr
-	}
-
-	//Probably use xaoSvcCtx
-	if rv := C.WrapxaoSvcCtx((*C.OraText)(unsafe.Pointer(c_dsn))); rv.rv == C.OCI_SUCCESS || rv.rv == C.OCI_SUCCESS_WITH_INFO {
-		conn.svc = rv.ptr
-	} else {
-
-		var host string
-		if dsn.Host != "" && dsn.SID != "" {
-			host = fmt.Sprintf("%s:%d/%s", dsn.Host, dsn.Port, dsn.SID)
+		if rv := C.WrapOCIHandleAlloc(
+			conn.env,
+			C.OCI_HTYPE_ERROR,
+			0); rv.rv != C.OCI_SUCCESS {
+			return nil, errors.New("cant  allocate error handle")
 		} else {
-			host = dsn.SID
-		}
-		phost := C.CString(host)
-		defer C.free(unsafe.Pointer(phost))
-		puser := C.CString(dsn.Username)
-		defer C.free(unsafe.Pointer(puser))
-		ppass := C.CString(dsn.Password)
-		defer C.free(unsafe.Pointer(ppass))
-
-		if rv := C.WrapOCILogon(
-			(*C.OCIEnv)(conn.env),
-			(*C.OCIError)(conn.err),
-			(*C.OraText)(unsafe.Pointer(puser)),
-			C.ub4(len(dsn.Username)),
-			(*C.OraText)(unsafe.Pointer(ppass)),
-			C.ub4(len(dsn.Password)),
-			(*C.OraText)(unsafe.Pointer(phost)),
-			C.ub4(len(host))); rv.rv != C.OCI_SUCCESS {
-			return nil, ociGetError(conn.err)
-		} else {
-			conn.svc = rv.ptr
+			conn.err = rv.ptr
 		}
 
-		conn.location = dsn.Location
-		conn.transactionMode = dsn.transactionMode
-	}
+        phost := C.CString(dsn.Connect)
+        defer C.free(unsafe.Pointer(phost))
+        puser := C.CString(dsn.Username)
+        defer C.free(unsafe.Pointer(puser))
+        ppass := C.CString(dsn.Password)
+        defer C.free(unsafe.Pointer(ppass))
 
-	c := &conn
-	runtime.SetFinalizer(c, (*OCI8Conn).Close)
-	return c, nil
+        if rv := C.WrapOCILogon(
+        	(*C.OCIEnv)(conn.env),
+        	(*C.OCIError)(conn.err),
+        	(*C.OraText)(unsafe.Pointer(puser)),
+        	C.ub4(len(dsn.Username)),
+        	(*C.OraText)(unsafe.Pointer(ppass)),
+        	C.ub4(len(dsn.Password)),
+        	(*C.OraText)(unsafe.Pointer(phost)),
+        	C.ub4(len(dsn.Connect))); rv.rv != C.OCI_SUCCESS && rv.rv != C.OCI_SUCCESS_WITH_INFO {
+        	return nil, ociGetError(rv.rv, conn.err)
+        } else {
+        	conn.svc = rv.ptr
+        }
+	}
+	conn.location = dsn.Location
+	conn.transactionMode = dsn.transactionMode
+	conn.prefetch_rows = dsn.prefetch_rows
+	conn.prefetch_memory = dsn.prefetch_memory
+	conn.enableQMPlaceholders = dsn.enableQMPlaceholders
+	return &conn, nil
 }
 
 func (c *OCI8Conn) Close() error {
@@ -651,7 +625,7 @@ func (c *OCI8Conn) Close() error {
 	if rv := C.OCILogoff(
 		(*C.OCISvcCtx)(c.svc),
 		(*C.OCIError)(c.err)); rv != C.OCI_SUCCESS {
-		err = ociGetError(c.err)
+		err = ociGetError(rv, c.err)
 	}
 
 	C.OCIHandleFree(
@@ -661,7 +635,6 @@ func (c *OCI8Conn) Close() error {
 	c.svc = nil
 	c.env = nil
 	c.err = nil
-	runtime.SetFinalizer(c, nil)
 	return err
 }
 
@@ -674,6 +647,9 @@ type OCI8Stmt struct {
 }
 
 func (c *OCI8Conn) Prepare(query string) (driver.Stmt, error) {
+	if c.enableQMPlaceholders {
+		query = placeholders(query)
+	}
 	pquery := C.CString(query)
 	defer C.free(unsafe.Pointer(pquery))
 	var s, bp, defp unsafe.Pointer
@@ -682,7 +658,7 @@ func (c *OCI8Conn) Prepare(query string) (driver.Stmt, error) {
 		c.env,
 		C.OCI_HTYPE_STMT,
 		(C.size_t)(unsafe.Sizeof(bp)*2)); rv.rv != C.OCI_SUCCESS {
-		return nil, ociGetError(c.err)
+		return nil, ociGetError(rv.rv, c.err)
 	} else {
 		s = rv.ptr
 		bp = rv.extra
@@ -696,12 +672,10 @@ func (c *OCI8Conn) Prepare(query string) (driver.Stmt, error) {
 		C.ub4(C.strlen(pquery)),
 		C.ub4(C.OCI_NTV_SYNTAX),
 		C.ub4(C.OCI_DEFAULT)); rv != C.OCI_SUCCESS {
-		return nil, ociGetError(c.err)
+		return nil, ociGetError(rv, c.err)
 	}
 
-	ss := &OCI8Stmt{c: c, s: s, bp: (**C.OCIBind)(bp), defp: (**C.OCIDefine)(defp)}
-	runtime.SetFinalizer(ss, (*OCI8Stmt).Close)
-	return ss, nil
+	return &OCI8Stmt{c: c, s: s, bp: (**C.OCIBind)(bp), defp: (**C.OCIDefine)(defp)}, nil
 }
 
 func (s *OCI8Stmt) Close() error {
@@ -714,7 +688,6 @@ func (s *OCI8Stmt) Close() error {
 		s.s,
 		C.OCI_HTYPE_STMT)
 	s.s = nil
-	runtime.SetFinalizer(s, nil)
 	return nil
 }
 
@@ -750,7 +723,7 @@ func freeBoundParameters(boundParameters []oci8bind) {
 }
 
 func (s *OCI8Stmt) bind(args []driver.Value) (boundParameters []oci8bind, err error) {
-	if args == nil {
+	if len(args) == 0 {
 		return nil, nil
 	}
 
@@ -760,22 +733,21 @@ func (s *OCI8Stmt) bind(args []driver.Value) (boundParameters []oci8bind, err er
 		clen  C.sb4
 	)
 	*s.bp = nil
-	for i, v := range args {
+	for i, uv := range args {
 
-		switch v.(type) {
+		switch v := uv.(type) {
 		case nil:
 			dty = C.SQLT_STR
 			cdata = nil
 			clen = 0
 		case []byte:
-			v := v.([]byte)
 			dty = C.SQLT_BIN
 			cdata = CByte(v)
 			clen = C.sb4(len(v))
 			boundParameters = append(boundParameters, oci8bind{dty, unsafe.Pointer(cdata)})
 
 		case float64:
-			fb := math.Float64bits(v.(float64))
+			fb := math.Float64bits(v)
 			if fb&0x8000000000000000 != 0 {
 				fb ^= 0xffffffffffffffff
 			} else {
@@ -791,21 +763,9 @@ func (s *OCI8Stmt) bind(args []driver.Value) (boundParameters []oci8bind, err er
 			var pt unsafe.Pointer
 			var zp unsafe.Pointer
 
-			now := v.(time.Time)
-			_, offset := now.Zone()
+			zone, offset := v.Zone()
 
-			sign := '+'
-			if offset < 0 {
-				offset = -offset
-				sign = '-'
-			}
-			offset /= 60
-
-			// oracle accepts zones "[+-]hh:mm"
-			zone := fmt.Sprintf("%c%02d:%02d", sign, offset/60, offset%60)
-			zoneTxt := now.Location().String()
-
-			size := len(zoneTxt)
+			size := len(zone)
 			if size < 8 {
 				size = 8
 			}
@@ -815,7 +775,7 @@ func (s *OCI8Stmt) bind(args []driver.Value) (boundParameters []oci8bind, err er
 				C.OCI_DTYPE_TIMESTAMP_TZ,
 				C.size_t(size)); ret.rv != C.OCI_SUCCESS {
 				defer freeBoundParameters(boundParameters)
-				return nil, ociGetError(s.c.err)
+				return nil, ociGetError(ret.rv, s.c.err)
 			} else {
 				dty = C.SQLT_TIMESTAMP_TZ
 				clen = C.sb4(unsafe.Sizeof(pt))
@@ -825,62 +785,99 @@ func (s *OCI8Stmt) bind(args []driver.Value) (boundParameters []oci8bind, err er
 				boundParameters = append(boundParameters, oci8bind{dty, pt})
 
 			}
-			for first := true; ; first = false {
+
+			tryagain := false
+
+			copy((*[1 << 30]byte)(zp)[0:len(zone)], zone)
+			rv := C.OCIDateTimeConstruct(
+				s.c.env,
+				(*C.OCIError)(s.c.err),
+				(*C.OCIDateTime)(*(*unsafe.Pointer)(pt)),
+				C.sb2(v.Year()),
+				C.ub1(v.Month()),
+				C.ub1(v.Day()),
+				C.ub1(v.Hour()),
+				C.ub1(v.Minute()),
+				C.ub1(v.Second()),
+				C.ub4(v.Nanosecond()),
+				(*C.OraText)(zp),
+				C.size_t(len(zone)),
+			)
+			if rv != C.OCI_SUCCESS {
+				tryagain = true
+			} else {
+				//check if oracle timezone offset is same ?
+				rvz := C.WrapOCIDateTimeGetTimeZoneNameOffset(
+					(*C.OCIEnv)(s.c.env),
+					(*C.OCIError)(s.c.err),
+					(*C.OCIDateTime)(*(*unsafe.Pointer)(pt)))
+				if rvz.rv != C.OCI_SUCCESS {
+					return nil, ociGetError(rvz.rv, s.c.err)
+				}
+				if offset != int(rvz.h)*60*60+int(rvz.m)*60 {
+					//fmt.Println("oracle timezone offset dont match", zone, offset, int(rvz.h)*60*60+int(rvz.m)*60)
+					tryagain = true
+				}
+			}
+
+			if tryagain {
+				sign := '+'
+				if offset < 0 {
+					offset = -offset
+					sign = '-'
+				}
+				offset /= 60
+				// oracle accept zones "[+-]hh:mm", try second time
+				zone = fmt.Sprintf("%c%02d:%02d", sign, offset/60, offset%60)
+
 				copy((*[1 << 30]byte)(zp)[0:len(zone)], zone)
 				rv := C.OCIDateTimeConstruct(
 					s.c.env,
 					(*C.OCIError)(s.c.err),
 					(*C.OCIDateTime)(*(*unsafe.Pointer)(pt)),
-					C.sb2(now.Year()),
-					C.ub1(now.Month()),
-					C.ub1(now.Day()),
-					C.ub1(now.Hour()),
-					C.ub1(now.Minute()),
-					C.ub1(now.Second()),
-					C.ub4(now.Nanosecond()),
+					C.sb2(v.Year()),
+					C.ub1(v.Month()),
+					C.ub1(v.Day()),
+					C.ub1(v.Hour()),
+					C.ub1(v.Minute()),
+					C.ub1(v.Second()),
+					C.ub4(v.Nanosecond()),
 					(*C.OraText)(zp),
 					C.size_t(len(zone)),
 				)
 				if rv != C.OCI_SUCCESS {
-					if !first {
-						defer freeBoundParameters(boundParameters)
-						return nil, ociGetError(s.c.err)
-					}
-					zone = zoneTxt
-				} else {
-					break
+					defer freeBoundParameters(boundParameters)
+					return nil, ociGetError(rv, s.c.err)
 				}
 			}
 
 			cdata = (*C.char)(pt)
 
 		case string:
-			v := v.(string)
 			dty = C.SQLT_AFC // don't trim strings !!!
 			cdata = C.CString(v)
 			clen = C.sb4(len(v))
 			boundParameters = append(boundParameters, oci8bind{dty, unsafe.Pointer(cdata)})
 		case int64:
-			val := v.(int64)
 			dty = C.SQLT_INT
 			clen = C.sb4(8) // not tested on i386. may only work on amd64
 			cdata = (*C.char)(C.malloc(8))
 			buf := (*[1 << 30]byte)(unsafe.Pointer(cdata))[0:8]
-			buf[0] = byte(val & 0x0ff)
-			buf[1] = byte(val >> 8 & 0x0ff)
-			buf[2] = byte(val >> 16 & 0x0ff)
-			buf[3] = byte(val >> 24 & 0x0ff)
-			buf[4] = byte(val >> 32 & 0x0ff)
-			buf[5] = byte(val >> 40 & 0x0ff)
-			buf[6] = byte(val >> 48 & 0x0ff)
-			buf[7] = byte(val >> 56 & 0x0ff)
+			buf[0] = byte(v & 0x0ff)
+			buf[1] = byte(v >> 8 & 0x0ff)
+			buf[2] = byte(v >> 16 & 0x0ff)
+			buf[3] = byte(v >> 24 & 0x0ff)
+			buf[4] = byte(v >> 32 & 0x0ff)
+			buf[5] = byte(v >> 40 & 0x0ff)
+			buf[6] = byte(v >> 48 & 0x0ff)
+			buf[7] = byte(v >> 56 & 0x0ff)
 			boundParameters = append(boundParameters, oci8bind{dty, unsafe.Pointer(cdata)})
 
 		case bool: // oracle dont have bool, handle as 0/1
 			dty = C.SQLT_INT
 			clen = C.sb4(1)
 			cdata = (*C.char)(C.malloc(10))
-			if v.(bool) {
+			if v {
 				*cdata = 1
 			} else {
 				*cdata = 0
@@ -910,7 +907,7 @@ func (s *OCI8Stmt) bind(args []driver.Value) (boundParameters []oci8bind, err er
 			nil,
 			C.OCI_DEFAULT); rv != C.OCI_SUCCESS {
 			defer freeBoundParameters(boundParameters)
-			return nil, ociGetError(s.c.err)
+			return nil, ociGetError(rv, s.c.err)
 		}
 	}
 	return boundParameters, nil
@@ -929,28 +926,28 @@ func (s *OCI8Stmt) Query(args []driver.Value) (rows driver.Rows, err error) {
 
 	iter := C.ub4(1)
 	if retUb2 := C.WrapOCIAttrGetUb2(s.s, C.OCI_HTYPE_STMT, C.OCI_ATTR_STMT_TYPE, (*C.OCIError)(s.c.err)); retUb2.rv != C.OCI_SUCCESS {
-		return nil, ociGetError(s.c.err)
+		return nil, ociGetError(retUb2.rv, s.c.err)
 	} else if retUb2.num == C.OCI_STMT_SELECT {
 		iter = 0
 	}
 
 	// set the row prefetch.  Only one extra row per fetch will be returned unless this is set.
-	if prefetch_size := C.ub4(s.c.attrs.Get("prefetch_rows").(int)); prefetch_size > 0 {
-		if rv := C.WrapOCIAttrSetUb4(s.s, C.OCI_HTYPE_STMT, prefetch_size, C.OCI_ATTR_PREFETCH_ROWS, (*C.OCIError)(s.c.err)); rv != C.OCI_SUCCESS {
-			return nil, ociGetError(s.c.err)
+	if s.c.prefetch_rows > 0 {
+		if rv := C.WrapOCIAttrSetUb4(s.s, C.OCI_HTYPE_STMT, C.ub4(s.c.prefetch_rows), C.OCI_ATTR_PREFETCH_ROWS, (*C.OCIError)(s.c.err)); rv != C.OCI_SUCCESS {
+			return nil, ociGetError(rv, s.c.err)
 		}
 	}
 
 	// if non-zero, oci will fetch rows until the memory limit or row prefetch limit is hit.
 	// useful for memory constrained systems
-	if prefetch_memory := C.ub4(s.c.attrs.Get("prefetch_memory").(int64)); prefetch_memory > 0 {
-		if rv := C.WrapOCIAttrSetUb4(s.s, C.OCI_HTYPE_STMT, prefetch_memory, C.OCI_ATTR_PREFETCH_MEMORY, (*C.OCIError)(s.c.err)); rv != C.OCI_SUCCESS {
-			return nil, ociGetError(s.c.err)
+	if s.c.prefetch_memory > 0 {
+		if rv := C.WrapOCIAttrSetUb4(s.s, C.OCI_HTYPE_STMT, C.ub4(s.c.prefetch_memory), C.OCI_ATTR_PREFETCH_MEMORY, (*C.OCIError)(s.c.err)); rv != C.OCI_SUCCESS {
+			return nil, ociGetError(rv, s.c.err)
 		}
 	}
 
 	mode := C.ub4(C.OCI_DEFAULT)
-	if !s.c.inTransaction && false == s.c.isXA {
+	if !s.c.inTransaction && false == s.c.is_xa {
 		mode = mode | C.OCI_COMMIT_ON_SUCCESS
 	}
 	if rv := C.OCIStmtExecute(
@@ -962,42 +959,44 @@ func (s *OCI8Stmt) Query(args []driver.Value) (rows driver.Rows, err error) {
 		nil,
 		nil,
 		mode); rv != C.OCI_SUCCESS {
-		return nil, ociGetError(s.c.err)
+		return nil, ociGetError(rv, s.c.err)
 	}
 
 	var rc int
 	if retUb2 := C.WrapOCIAttrGetUb2(s.s, C.OCI_HTYPE_STMT, C.OCI_ATTR_PARAM_COUNT, (*C.OCIError)(s.c.err)); retUb2.rv != C.OCI_SUCCESS {
-		return nil, ociGetError(s.c.err)
+		return nil, ociGetError(retUb2.rv, s.c.err)
 	} else {
 		rc = int(retUb2.num)
 	}
 
 	oci8cols := make([]oci8col, rc)
+	indrlenptr := C.calloc(C.size_t(rc), C.sizeof_indrlen)
+	indrlen := (*[1 << 16]C.indrlen)(indrlenptr)[0:rc]
 	for i := 0; i < rc; i++ {
 		var p unsafe.Pointer
 		var tp C.ub2
 		var lp C.ub2
 
 		if rp := C.WrapOCIParamGet(s.s, C.OCI_HTYPE_STMT, (*C.OCIError)(s.c.err), C.ub4(i+1)); rp.rv != C.OCI_SUCCESS {
-			return nil, ociGetError(s.c.err)
+			return nil, ociGetError(rp.rv, s.c.err)
 		} else {
 			p = rp.ptr
 		}
 
 		if tpr := C.WrapOCIAttrGetUb2(p, C.OCI_DTYPE_PARAM, C.OCI_ATTR_DATA_TYPE, (*C.OCIError)(s.c.err)); tpr.rv != C.OCI_SUCCESS {
-			return nil, ociGetError(s.c.err)
+			return nil, ociGetError(tpr.rv, s.c.err)
 		} else {
 			tp = tpr.num
 		}
 
 		if nsr := C.WrapOCIAttrGetString(p, C.OCI_DTYPE_PARAM, C.OCI_ATTR_NAME, (*C.OCIError)(s.c.err)); nsr.rv != C.OCI_SUCCESS {
-			return nil, ociGetError(s.c.err)
+			return nil, ociGetError(nsr.rv, s.c.err)
 		} else {
 			oci8cols[i].name = string((*[1 << 30]byte)(unsafe.Pointer(nsr.ptr))[0:int(nsr.size)])
 		}
 
 		if lpr := C.WrapOCIAttrGetUb2(p, C.OCI_DTYPE_PARAM, C.OCI_ATTR_DATA_SIZE, (*C.OCIError)(s.c.err)); lpr.rv != C.OCI_SUCCESS {
-			return nil, ociGetError(s.c.err)
+			return nil, ociGetError(lpr.rv, s.c.err)
 		} else {
 			lp = lpr.num
 		}
@@ -1040,7 +1039,7 @@ func (s *OCI8Stmt) Query(args []driver.Value) (rows driver.Rows, err error) {
 				size += oci8cols[i].size
 			}
 			if ret := C.WrapOCIDescriptorAlloc(s.c.env, C.OCI_DTYPE_LOB, C.size_t(size)); ret.rv != C.OCI_SUCCESS {
-				return nil, ociGetError(s.c.err)
+				return nil, ociGetError(ret.rv, s.c.err)
 			} else {
 
 				oci8cols[i].kind = tp
@@ -1060,7 +1059,7 @@ func (s *OCI8Stmt) Query(args []driver.Value) (rows driver.Rows, err error) {
 
 		case C.SQLT_TIMESTAMP, C.SQLT_DAT:
 			if ret := C.WrapOCIDescriptorAlloc(s.c.env, C.OCI_DTYPE_TIMESTAMP, C.size_t(unsafe.Sizeof(unsafe.Pointer(nil)))); ret.rv != C.OCI_SUCCESS {
-				return nil, ociGetError(s.c.err)
+				return nil, ociGetError(ret.rv, s.c.err)
 			} else {
 
 				oci8cols[i].kind = C.SQLT_TIMESTAMP
@@ -1071,7 +1070,7 @@ func (s *OCI8Stmt) Query(args []driver.Value) (rows driver.Rows, err error) {
 
 		case C.SQLT_TIMESTAMP_TZ, C.SQLT_TIMESTAMP_LTZ:
 			if ret := C.WrapOCIDescriptorAlloc(s.c.env, C.OCI_DTYPE_TIMESTAMP_TZ, C.size_t(unsafe.Sizeof(unsafe.Pointer(nil)))); ret.rv != C.OCI_SUCCESS {
-				return nil, ociGetError(s.c.err)
+				return nil, ociGetError(ret.rv, s.c.err)
 			} else {
 
 				oci8cols[i].kind = C.SQLT_TIMESTAMP_TZ
@@ -1082,7 +1081,7 @@ func (s *OCI8Stmt) Query(args []driver.Value) (rows driver.Rows, err error) {
 
 		case C.SQLT_INTERVAL_DS:
 			if ret := C.WrapOCIDescriptorAlloc(s.c.env, C.OCI_DTYPE_INTERVAL_DS, C.size_t(unsafe.Sizeof(unsafe.Pointer(nil)))); ret.rv != C.OCI_SUCCESS {
-				return nil, ociGetError(s.c.err)
+				return nil, ociGetError(ret.rv, s.c.err)
 			} else {
 
 				oci8cols[i].kind = C.SQLT_INTERVAL_DS
@@ -1093,7 +1092,7 @@ func (s *OCI8Stmt) Query(args []driver.Value) (rows driver.Rows, err error) {
 
 		case C.SQLT_INTERVAL_YM:
 			if ret := C.WrapOCIDescriptorAlloc(s.c.env, C.OCI_DTYPE_INTERVAL_YM, C.size_t(unsafe.Sizeof(unsafe.Pointer(nil)))); ret.rv != C.OCI_SUCCESS {
-				return nil, ociGetError(s.c.err)
+				return nil, ociGetError(ret.rv, s.c.err)
 			} else {
 
 				oci8cols[i].kind = C.SQLT_INTERVAL_YM
@@ -1114,6 +1113,9 @@ func (s *OCI8Stmt) Query(args []driver.Value) (rows driver.Rows, err error) {
 			oci8cols[i].size = int(lp + 1)
 		}
 
+		oci8cols[i].ind = &indrlen[i].ind
+		oci8cols[i].rlen = &indrlen[i].rlen
+
 		if rv := C.OCIDefineByPos(
 			(*C.OCIStmt)(s.s),
 			s.defp,
@@ -1122,14 +1124,15 @@ func (s *OCI8Stmt) Query(args []driver.Value) (rows driver.Rows, err error) {
 			oci8cols[i].pbuf,
 			C.sb4(oci8cols[i].size),
 			oci8cols[i].kind,
-			unsafe.Pointer(&oci8cols[i].ind),
-			&oci8cols[i].rlen,
+			unsafe.Pointer(oci8cols[i].ind),
+			oci8cols[i].rlen,
 			nil,
 			C.OCI_DEFAULT); rv != C.OCI_SUCCESS {
-			return nil, ociGetError(s.c.err)
+			C.free(indrlenptr)
+			return nil, ociGetError(rv, s.c.err)
 		}
 	}
-	return &OCI8Rows{s, oci8cols, false}, nil
+	return &OCI8Rows{s, oci8cols, false, indrlenptr}, nil
 }
 
 // OCI_ATTR_ROWID must be get in handle -> alloc
@@ -1160,7 +1163,7 @@ func (s *OCI8Stmt) lastInsertId() (int64, error) {
 func (s *OCI8Stmt) rowsAffected() (int64, error) {
 	retUb4 := C.WrapOCIAttrGetUb4(s.s, C.OCI_HTYPE_STMT, C.OCI_ATTR_ROW_COUNT, (*C.OCIError)(s.c.err))
 	if retUb4.rv != C.OCI_SUCCESS {
-		return 0, ociGetError(s.c.err)
+		return 0, ociGetError(retUb4.rv, s.c.err)
 	}
 	return int64(retUb4.num), nil
 }
@@ -1193,7 +1196,7 @@ func (s *OCI8Stmt) Exec(args []driver.Value) (r driver.Result, err error) {
 	defer freeBoundParameters(fbp)
 
 	mode := C.ub4(C.OCI_DEFAULT)
-	if s.c.inTransaction == false && false == s.c.isXA {
+	if s.c.inTransaction == false && false == s.c.is_xa {
 		mode = mode | C.OCI_COMMIT_ON_SUCCESS
 	}
 
@@ -1207,7 +1210,7 @@ func (s *OCI8Stmt) Exec(args []driver.Value) (r driver.Result, err error) {
 		nil,
 		mode)
 	if rv != C.OCI_SUCCESS {
-		return nil, ociGetError(s.c.err)
+		return nil, ociGetError(rv, s.c.err)
 	}
 
 	n, en := s.rowsAffected()
@@ -1223,8 +1226,8 @@ type oci8col struct {
 	name string
 	kind C.ub2
 	size int
-	ind  C.sb2
-	rlen C.ub2
+	ind  *C.sb2
+	rlen *C.ub2
 	pbuf unsafe.Pointer
 }
 
@@ -1234,9 +1237,10 @@ type oci8bind struct {
 }
 
 type OCI8Rows struct {
-	s    *OCI8Stmt
-	cols []oci8col
-	e    bool
+	s          *OCI8Stmt
+	cols       []oci8col
+	e          bool
+	indrlenptr unsafe.Pointer
 }
 
 func freeDecriptor(p unsafe.Pointer, dtype C.ub4) {
@@ -1245,6 +1249,7 @@ func freeDecriptor(p unsafe.Pointer, dtype C.ub4) {
 }
 
 func (rc *OCI8Rows) Close() error {
+	C.free(rc.indrlenptr)
 	for _, col := range rc.cols {
 		switch col.kind {
 		case C.SQLT_CLOB, C.SQLT_BLOB:
@@ -1283,21 +1288,21 @@ func (rc *OCI8Rows) Next(dest []driver.Value) error {
 	if rv == C.OCI_NO_DATA {
 		return io.EOF
 	} else if rv != C.OCI_SUCCESS {
-		return ociGetError(rc.s.c.err)
+		return ociGetError(rv, rc.s.c.err)
 	}
 
 	for i := range dest {
 		// TODO: switch rc.cols[i].ind
-		if rc.cols[i].ind == -1 { // Null
+		if *rc.cols[i].ind == -1 { // Null
 			dest[i] = nil
 			continue
-		} else if rc.cols[i].ind != 0 {
+		} else if *rc.cols[i].ind != 0 {
 			return errors.New(fmt.Sprintf("Unknown column indicator: %d, col %s", rc.cols[i].ind, rc.cols[i].name))
 		}
 
 		switch rc.cols[i].kind {
 		case C.SQLT_DAT: // for test, date are return as timestamp
-			buf := (*[1 << 30]byte)(unsafe.Pointer(rc.cols[i].pbuf))[0:rc.cols[i].rlen]
+			buf := (*[1 << 30]byte)(unsafe.Pointer(rc.cols[i].pbuf))[0:*rc.cols[i].rlen]
 			// TODO: Handle BCE dates (http://docs.oracle.com/cd/B12037_01/appdev.101/b10779/oci03typ.htm#438305)
 			// TODO: Handle timezones (http://docs.oracle.com/cd/B12037_01/appdev.101/b10779/oci03typ.htm#443601)
 			dest[i] = time.Date(
@@ -1312,11 +1317,11 @@ func (rc *OCI8Rows) Next(dest []driver.Value) error {
 		case C.SQLT_BLOB, C.SQLT_CLOB:
 			ptmp := unsafe.Pointer(uintptr(rc.cols[i].pbuf) + unsafe.Sizeof(unsafe.Pointer(nil)))
 			bamt := (*C.ub4)(ptmp)
-			*bamt = 0
 			ptmp = unsafe.Pointer(uintptr(rc.cols[i].pbuf) + unsafe.Sizeof(C.ub4(0)) + unsafe.Sizeof(unsafe.Pointer(nil)))
 			b := (*[1 << 30]byte)(ptmp)[0:blobBufSize]
 			var buf []byte
 		again:
+			*bamt = 0
 			rv = C.OCILobRead(
 				(*C.OCISvcCtx)(rc.s.c.svc),
 				(*C.OCIError)(rc.s.c.err),
@@ -1334,7 +1339,7 @@ func (rc *OCI8Rows) Next(dest []driver.Value) error {
 				goto again
 			}
 			if rv != C.OCI_SUCCESS {
-				return ociGetError(rc.s.c.err)
+				return ociGetError(rv, rc.s.c.err)
 			}
 			if rc.cols[i].kind == C.SQLT_BLOB {
 				dest[i] = append(buf, b[:int(*bamt)]...)
@@ -1342,18 +1347,18 @@ func (rc *OCI8Rows) Next(dest []driver.Value) error {
 				dest[i] = string(append(buf, b[:int(*bamt)]...))
 			}
 		case C.SQLT_CHR, C.SQLT_AFC, C.SQLT_AVC:
-			buf := (*[1 << 30]byte)(unsafe.Pointer(rc.cols[i].pbuf))[0:rc.cols[i].rlen]
+			buf := (*[1 << 30]byte)(unsafe.Pointer(rc.cols[i].pbuf))[0:*rc.cols[i].rlen]
 			switch {
-			case rc.cols[i].ind == 0: // Normal
+			case *rc.cols[i].ind == 0: // Normal
 				dest[i] = string(buf)
-			case rc.cols[i].ind == -2 || // Field longer than type (truncated)
-				rc.cols[i].ind > 0: // Field longer than type (truncated). Value is original length.
+			case *rc.cols[i].ind == -2 || // Field longer than type (truncated)
+				*rc.cols[i].ind > 0: // Field longer than type (truncated). Value is original length.
 				dest[i] = string(buf)
 			default:
 				return errors.New(fmt.Sprintf("Unknown column indicator: %d", rc.cols[i].ind))
 			}
 		case C.SQLT_BIN: // RAW
-			buf := (*[1 << 30]byte)(unsafe.Pointer(rc.cols[i].pbuf))[0:rc.cols[i].rlen]
+			buf := (*[1 << 30]byte)(unsafe.Pointer(rc.cols[i].pbuf))[0:*rc.cols[i].rlen]
 			dest[i] = buf
 		case C.SQLT_NUM: // NUMBER
 			buf := (*[21]byte)(unsafe.Pointer(rc.cols[i].pbuf))
@@ -1362,10 +1367,10 @@ func (rc *OCI8Rows) Next(dest []driver.Value) error {
 			buf := (*[22]byte)(unsafe.Pointer(rc.cols[i].pbuf))
 			dest[i] = buf
 		case C.SQLT_INT: // INT
-			buf := (*[1 << 30]byte)(unsafe.Pointer(rc.cols[i].pbuf))[0:rc.cols[i].rlen]
+			buf := (*[1 << 30]byte)(unsafe.Pointer(rc.cols[i].pbuf))[0:*rc.cols[i].rlen]
 			dest[i] = buf
 		case C.SQLT_LNG: // LONG
-			buf := (*[1 << 30]byte)(unsafe.Pointer(rc.cols[i].pbuf))[0:rc.cols[i].rlen]
+			buf := (*[1 << 30]byte)(unsafe.Pointer(rc.cols[i].pbuf))[0:*rc.cols[i].rlen]
 			dest[i] = buf
 		case C.SQLT_IBDOUBLE, C.SQLT_IBFLOAT:
 			colsize := rc.cols[i].size
@@ -1410,7 +1415,7 @@ func (rc *OCI8Rows) Next(dest []driver.Value) error {
 				(*C.OCIError)(rc.s.c.err),
 				*(**C.OCIDateTime)(rc.cols[i].pbuf),
 			); rv.rv != C.OCI_SUCCESS {
-				return ociGetError(rc.s.c.err)
+				return ociGetError(rv.rv, rc.s.c.err)
 			} else {
 				dest[i] = time.Date(
 					int(rv.y),
@@ -1429,14 +1434,14 @@ func (rc *OCI8Rows) Next(dest []driver.Value) error {
 				(*C.OCIError)(rc.s.c.err),
 				tptr)
 			if rv.rv != C.OCI_SUCCESS {
-				return ociGetError(rc.s.c.err)
+				return ociGetError(rv.rv, rc.s.c.err)
 			}
 			rvz := C.WrapOCIDateTimeGetTimeZoneNameOffset(
 				(*C.OCIEnv)(rc.s.c.env),
 				(*C.OCIError)(rc.s.c.err),
 				tptr)
 			if rvz.rv != C.OCI_SUCCESS {
-				return ociGetError(rc.s.c.err)
+				return ociGetError(rvz.rv, rc.s.c.err)
 			}
 			nnn := C.GoStringN((*C.char)((unsafe.Pointer)(&rvz.zone[0])), C.int(rvz.zlen))
 			loc, err := time.LoadLocation(nnn)
@@ -1460,7 +1465,7 @@ func (rc *OCI8Rows) Next(dest []driver.Value) error {
 				(*C.OCIError)(rc.s.c.err),
 				iptr)
 			if rv.rv != C.OCI_SUCCESS {
-				return ociGetError(rc.s.c.err)
+				return ociGetError(rv.rv, rc.s.c.err)
 			}
 			dest[i] = int64(time.Duration(rv.d)*time.Hour*24 + time.Duration(rv.hh)*time.Hour + time.Duration(rv.mm)*time.Minute + time.Duration(rv.ss)*time.Second + time.Duration(rv.ff))
 		case C.SQLT_INTERVAL_YM:
@@ -1470,7 +1475,7 @@ func (rc *OCI8Rows) Next(dest []driver.Value) error {
 				(*C.OCIError)(rc.s.c.err),
 				iptr)
 			if rv.rv != C.OCI_SUCCESS {
-				return ociGetError(rc.s.c.err)
+				return ociGetError(rv.rv, rc.s.c.err)
 			}
 			dest[i] = int64(rv.y)*12 + int64(rv.m)
 		default:
@@ -1481,27 +1486,32 @@ func (rc *OCI8Rows) Next(dest []driver.Value) error {
 	return nil
 }
 
-func ociGetError(err unsafe.Pointer) error {
+func ociGetErrorS(err unsafe.Pointer) error {
 	rv := C.WrapOCIErrorGet((*C.OCIError)(err))
 	s := C.GoString(&rv.err[0])
 	return errors.New(s)
 }
 
-func parseEnviron(env []string) (out map[string]interface{}) {
-	out = make(map[string]interface{})
-
-	for _, v := range env {
-		parts := strings.SplitN(v, "=", 2)
-
-		// Better to have a type error here than later during query execution
-		switch parts[0] {
-		case "PREFETCH_ROWS":
-			out["prefetch_rows"], _ = strconv.Atoi(parts[1])
-		case "PREFETCH_MEMORY":
-			out["prefetch_memory"], _ = strconv.ParseInt(parts[1], 10, 64)
-		}
+func ociGetError(rv C.sword, err unsafe.Pointer) error {
+	switch rv {
+	case C.OCI_INVALID_HANDLE:
+		return errors.New("OCI_INVALID_HANDLE")
+	case C.OCI_SUCCESS_WITH_INFO:
+		return errors.New("OCI_SUCCESS_WITH_INFO")
+	case C.OCI_RESERVED_FOR_INT_USE:
+		return errors.New("OCI_RESERVED_FOR_INT_USE")
+	case C.OCI_NO_DATA:
+		return errors.New("OCI_NO_DATA")
+	case C.OCI_NEED_DATA:
+		return errors.New("OCI_NEED_DATA")
+	case C.OCI_STILL_EXECUTING:
+		return errors.New("OCI_STILL_EXECUTING")
+	case C.OCI_SUCCESS:
+		panic("ociGetError called with no error")
+	case C.OCI_ERROR:
+		return ociGetErrorS(err)
 	}
-	return out
+	return fmt.Errorf("oracle return error code %d", rv)
 }
 
 func CByte(b []byte) *C.char {
@@ -1509,4 +1519,15 @@ func CByte(b []byte) *C.char {
 	pp := (*[1 << 30]byte)(p)
 	copy(pp[:], b)
 	return (*C.char)(p)
+}
+
+var phre = regexp.MustCompile(`\?`)
+
+// converts "?" characters to  :1, :2, ... :n
+func placeholders(sql string) string {
+	n := 0
+	return phre.ReplaceAllStringFunc(sql, func(string) string {
+		n++
+		return ":" + strconv.Itoa(n)
+	})
 }

--- a/oci8.go
+++ b/oci8.go
@@ -1,4 +1,4 @@
-0package oci8
+package oci8
 
 /*
 #include <oci.h>


### PR DESCRIPTION
Added support for XA transactions. When doing sql.Open("oci8", ""); i.e. with out connection string, the driver will try to acquire connection string from Oracle OCI XA subsystem. The example use can be seen here: https://github.com/endurox-dev/endurox-go/blob/master/tests/04_distributed_transaction/src/server/server.go

The XA sub-system is initialized by Enduro/X, and later by this patch it can be efficiently used in Go programs.