### PR TITLE
Enable compilation on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,20 +16,21 @@ This package can be installed with the go get command:
     go get github.com/mattn/go-oci8
 
 You need to put `oci8.pc` like into your `$PKG_CONFIG_PATH`. `oci8.pc` should be like below. This is an example for windows.
-
+PKG-CONFIG is required for compilation, either compiled from [source] (https://pkg-config.freedesktop.org/releases/) locally using the MingGW/MSYS toolchain or as binary as described on https://stackoverflow.com/questions/1710922/how-to-install-pkg-config-in-windows
 ```
-prefix=/devel/target/XXXXXXXXXXXXXXXXXXXXXXXXXX
+prefix=./target/
 exec_prefix=${prefix}
-libdir=c:/oraclexe/app/oracle/product/11.2.0/server/oci/lib/msvc
-includedir=c:/oraclexe/app/oracle/product/11.2.0/server/oci/include/include
+libdir=C:/Oracle/instantclient_12_1/oci.dll
+includedir=C:/Oracle/instantclient_12_1/sdk/include
 
 glib_genmarshal=glib-genmarshal
 gobject_query=gobject-query
 glib_mkenums=glib-mkenums
 
-Name: oci8
+Name: oci8_win
+Version: 12.1
 Description: oci8 library
-Libs: -L${libdir} -loci
+Libs: -L${libdir}
 Cflags: -I${includedir}
 ```
 

--- a/oci8.go
+++ b/oci8.go
@@ -6,7 +6,8 @@ package oci8
 #include <string.h>
 #include <stdint.h>
 
-#cgo pkg-config: oci8
+#cgo !windows pkg-config: oci8
+#cgo windows pkg-config: oci8_win
 
 typedef struct {
   char err[1024];

--- a/oci8_win.pc
+++ b/oci8_win.pc
@@ -1,0 +1,14 @@
+prefix=./target/
+exec_prefix=${prefix}
+libdir=C:/Oracle/instantclient_12_1/oci.dll
+includedir=C:/Oracle/instantclient_12_1/sdk/include
+
+glib_genmarshal=glib-genmarshal
+gobject_query=gobject-query
+glib_mkenums=glib-mkenums
+
+Name: oci8_win
+Version: 12.1
+Description: oci8 library
+Libs: -L${libdir}
+Cflags: -I${includedir}


### PR DESCRIPTION
For more "automatic" compilation I've added oci8_win.pc to the repository. This should be invoked using the updated cgo flags in oci8.go.
Eventually, I've updated the README.