### PR TITLE
Add oci8.pc example for Linux on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ go-oci8
 Description
 -----------
 
-oracle driver conforming to the built-in database/sql interface
+Oracle driver conforming to the built-in database/sql interface
 
 Installation
 ------------
@@ -15,7 +15,9 @@ This package can be installed with the go get command:
 
     go get github.com/mattn/go-oci8
 
-You need to put `oci8.pc` like into your `$PKG_CONFIG_PATH`. `oci8.pc` should be like below. This is an example for windows.
+You need to put `oci8.pc` like into your `$PKG_CONFIG_PATH`. `oci8.pc` should be like below.
+
+### Example for Windows
 
 ```
 prefix=/devel/target/XXXXXXXXXXXXXXXXXXXXXXXXXX
@@ -31,6 +33,26 @@ Name: oci8
 Description: oci8 library
 Libs: -L${libdir} -loci
 Cflags: -I${includedir}
+Version: 11.2
+```
+
+### Example for Linux
+
+```
+prefix=/devel/target/XXXXXXXXXXXXXXXXXXXXXXXXXX
+exec_prefix=${prefix}
+libdir=/usr/lib/oracle/11.2/client64/lib
+includedir=/usr/include/oracle/11.2/client64
+
+glib_genmarshal=glib-genmarshal
+gobject_query=gobject-query
+glib_mkenums=glib-mkenums
+
+Name: oci8
+Description: oci8 library
+Libs: -L${libdir} -lclntsh
+Cflags: -I${includedir}
+Version: 11.2
 ```
 
 Documentation


### PR DESCRIPTION
I took same time to find that `-loci` is Windows specific, and one should use `-lclntsh` to be able to compile on Linux.