### PR TITLE
Added driver.ErrBadConn for disconnect

### DIFF
--- a/oci8.go
+++ b/oci8.go
@@ -1466,6 +1466,9 @@ func (rc *OCI8Rows) Next(dest []driver.Value) error {
 func ociGetErrorS(err unsafe.Pointer) error {
 	rv := C.WrapOCIErrorGet((*C.OCIError)(err))
 	s := C.GoString(&rv.err[0])
+	if len(s) > 8 && (s[0:9] == "ORA-03114" || s[0:9] == "ORA-01012") {
+    return driver.ErrBadConn
+	}
 	return errors.New(s)
 }
 


### PR DESCRIPTION
Most Oracle database errors can be handled farther up in the problem but disconnected connections can not be handled. If you have a pool of connections and any one of the connections gets terminated or disconnected, the only way to reconnect is to close down all the connections and then reconnect. The GoLang sql package provides automatic reconnect but only if you pass up the driver.ErrBadConn error. So this change will let the GoLang sql package handle the reconnects on database disconnected or user not logged in, which is errors ORA-03114 and ORA-01012.