### PR TITLE
Always use UTF-8

### DIFF
--- a/oci8.go
+++ b/oci8.go
@@ -341,6 +341,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"os"
 	"regexp"
 	"strconv"
 	"strings"
@@ -364,6 +365,8 @@ type DSN struct {
 }
 
 func init() {
+	os.Setenv("NLS_LANG", "AMERICAN_AMERICA.AL32UTF8")
+
 	sql.Register("oci8", &OCI8Driver{})
 }
 


### PR DESCRIPTION
If the collation is not the default UTF-8, there are errors when this environment variable is not set.