### PR TITLE
Defered Close instruction on prepared statement

### DIFF
--- a/oci8.go
+++ b/oci8.go
@@ -539,7 +539,6 @@ func (c *OCI8Conn) exec(ctx context.Context, query string, args []namedValue) (d
 	}
 	res, err := s.(*OCI8Stmt).exec(ctx, args)
 	if err != nil && err != driver.ErrSkip {
-		s.Close()
 		return nil, err
 	}
 	return res, nil


### PR DESCRIPTION
When running db.Exec many times (approx 300 on Vagrant Test VM with oracle xe 11.2 ) within a single program, the "ORA-01000: maximum open cursors exceeded" is thrown. 