### PR TITLE
feat: add `ORA-03113` to bad connection

### DIFF
--- a/oci8.go
+++ b/oci8.go
@@ -1685,10 +1685,11 @@ func ociGetErrorS(err unsafe.Pointer) error {
 	return errors.New(s)
 }
 
-func isBadConnection(errorCode string) bool {
-	if len(errorCode) <= 8 {
+func isBadConnection(error string) bool {
+	if len(error) <= 8 {
 		return false
 	}
+	errorCode := error[0:9]
 	for _, badConnCode := range badConnCodes {
 		if badConnCode == errorCode {
 			return true

--- a/oci8.go
+++ b/oci8.go
@@ -362,6 +362,12 @@ import (
 )
 
 const blobBufSize = 4000
+/**
+	ORA-03114: Not Connected to Oracle
+	ORA-01012: Not logged on
+	ORA-03113: end-of-file on communication channel
+ */
+var badConnCodes = []string{"ORA-03114", "ORA-01012", "ORA-03113"}
 
 type DSN struct {
 	Connect              string
@@ -1673,10 +1679,22 @@ func (rc *OCI8Rows) Next(dest []driver.Value) (err error) {
 func ociGetErrorS(err unsafe.Pointer) error {
 	rv := C.WrapOCIErrorGet((*C.OCIError)(err))
 	s := C.GoString(&rv.err[0])
-	if len(s) > 8 && (s[0:9] == "ORA-03114" || s[0:9] == "ORA-01012") {
+	if isBadConnection(s) {
 		return driver.ErrBadConn
 	}
 	return errors.New(s)
+}
+
+func isBadConnection(errorCode string) bool {
+	if len(errorCode) <= 8 {
+		return false
+	}
+	for _, badConnCode := range badConnCodes {
+		if badConnCode == errorCode {
+			return true
+		}
+	}
+	return false
 }
 
 func ociGetError(rv C.sword, err unsafe.Pointer) error {

--- a/oci8_test.go
+++ b/oci8_test.go
@@ -37,3 +37,10 @@ func TestParseDSN(t *testing.T) {
 		}
 	}
 }
+
+func TestIsBadConn(t *testing.T) {
+	var errorCode = "ORA-03114"
+	if !isBadConnection(errorCode) {
+		t.Errorf("TestIsBadConn: expected %+v, actual %+v", true, isBadConnection(errorCode))
+	}
+}


### PR DESCRIPTION
`ORA-03113` is also a bad connection;

> The ORA-03113 error when connecting suggests that the connection was established, but lost later, like a timeout. 

more [detail](http://dba-oracle.com/m_ora_03113_end_of_file_on_communications_channel.htm)