### PR TITLE
fix problem with utf8 in clob

### DIFF
--- a/oci8.go
+++ b/oci8.go
@@ -1596,7 +1596,20 @@ func (rc *OCI8Rows) Next(dest []driver.Value) (err error) {
 				0,
 				C.SQLCS_IMPLICIT)
 			if rv == C.OCI_NEED_DATA {
-				buf = append(buf, b[:int(*bamt)]...)
+				if rc.cols[i].kind == C.SQLT_BLOB {
+					buf = append(buf, b[:int(*bamt)]...)
+				}else{
+					//bamt for clob is amount of chars, not bytes
+					if(*bamt>0){
+						for ii:=range b{
+							if(b[ii]==0) {
+								break
+							}
+							buf = append(buf, b[ii])
+							b[ii]=0
+						}
+					}
+				}
 				goto again
 			}
 			if rv != C.OCI_SUCCESS {
@@ -1605,7 +1618,18 @@ func (rc *OCI8Rows) Next(dest []driver.Value) (err error) {
 			if rc.cols[i].kind == C.SQLT_BLOB {
 				dest[i] = append(buf, b[:int(*bamt)]...)
 			} else {
-				dest[i] = string(append(buf, b[:int(*bamt)]...))
+				//dest[i] = string(append(buf, b[:int(*bamt)]...))
+				if(*bamt>0){
+					for ii:=range b{
+						if(b[ii]==0) {
+							break
+						}
+						buf = append(buf, b[ii])
+						b[ii]=0
+					}
+				}
+				fmt.Println(buf)
+				dest[i] = string(buf)
 			}
 		case C.SQLT_CHR, C.SQLT_AFC, C.SQLT_AVC:
 			buf := (*[1 << 30]byte)(unsafe.Pointer(rc.cols[i].pbuf))[0:*rc.cols[i].rlen]

--- a/oci8.go
+++ b/oci8.go
@@ -1628,7 +1628,6 @@ func (rc *OCI8Rows) Next(dest []driver.Value) (err error) {
 						b[ii]=0
 					}
 				}
-				fmt.Println(buf)
 				dest[i] = string(buf)
 			}
 		case C.SQLT_CHR, C.SQLT_AFC, C.SQLT_AVC:


### PR DESCRIPTION
OCILobRead return to bamt amout of chars. This is not equal with amount bytes in clob with some czech chars and b[:int(*bamt)] not work correctly.