### PR TITLE
Avoid runtime.SetFinalizer to close statements

### DIFF
--- a/oci8.go
+++ b/oci8.go
@@ -887,6 +887,7 @@ func (c *OCI8Conn) Close() error {
 	c.svc = nil
 	c.env = nil
 	c.err = nil
+	c.openOCI8Stmts = nil
 	return err
 }
 

--- a/oci8.go
+++ b/oci8.go
@@ -1532,7 +1532,7 @@ func (s *OCI8Stmt) query(ctx context.Context, args []namedValue) (driver.Rows, e
 		indrlenptr: indrlenptr,
 		closed:     false,
 		done:       make(chan struct{}),
-		cls:        false,
+		cls:        true,
 	}
 
 	go func() {

--- a/oci8.go
+++ b/oci8.go
@@ -640,7 +640,7 @@ func (c *OCI8Conn) query(ctx context.Context, query string, args []namedValue) (
 	if err != nil {
 		return nil, err
 	}
-	rows, err := s.(*OCI8Stmt).query(ctx, args)
+	rows, err := s.(*OCI8Stmt).query(ctx, args, true)
 	if err != nil && err != driver.ErrSkip {
 		s.Close()
 		return nil, err
@@ -1301,10 +1301,10 @@ func (s *OCI8Stmt) Query(args []driver.Value) (rows driver.Rows, err error) {
 			Value:   v,
 		}
 	}
-	return s.query(context.Background(), list)
+	return s.query(context.Background(), list, false)
 }
 
-func (s *OCI8Stmt) query(ctx context.Context, args []namedValue) (driver.Rows, error) {
+func (s *OCI8Stmt) query(ctx context.Context, args []namedValue, closeRows bool) (driver.Rows, error) {
 	var (
 		fbp []oci8bind
 		err error
@@ -1532,7 +1532,7 @@ func (s *OCI8Stmt) query(ctx context.Context, args []namedValue) (driver.Rows, e
 		indrlenptr: indrlenptr,
 		closed:     false,
 		done:       make(chan struct{}),
-		cls:        true,
+		cls:        closeRows,
 	}
 
 	go func() {

--- a/oci8.go
+++ b/oci8.go
@@ -887,7 +887,6 @@ func (c *OCI8Conn) Close() error {
 	c.svc = nil
 	c.env = nil
 	c.err = nil
-	c.openOCI8Stmts = nil
 	return err
 }
 

--- a/oci8.go
+++ b/oci8.go
@@ -432,7 +432,6 @@ type OCI8Conn struct {
 	inTransaction        bool
 	enableQMPlaceholders bool
 	closed               bool
-	openOCI8Stmts        []*OCI8Stmt
 }
 
 type OCI8Tx struct {
@@ -876,10 +875,6 @@ func (c *OCI8Conn) Close() error {
 		}
 	}
 
-	for _, openOCI8Stmt := range c.openOCI8Stmts {
-		err = openOCI8Stmt.Close()
-	}
-
 	C.OCIHandleFree(
 		c.env,
 		C.OCI_HTYPE_ENV)
@@ -934,8 +929,6 @@ func (c *OCI8Conn) prepare(ctx context.Context, query string) (driver.Stmt, erro
 
 	ss := &OCI8Stmt{c: c, s: s, bp: (**C.OCIBind)(bp), defp: (**C.OCIDefine)(defp)}
 	//runtime.SetFinalizer(ss, (*OCI8Stmt).Close)
-	c.openOCI8Stmts = append(c.openOCI8Stmts, ss)
-
 	return ss, nil
 }
 

--- a/oci8.go
+++ b/oci8.go
@@ -432,6 +432,7 @@ type OCI8Conn struct {
 	inTransaction        bool
 	enableQMPlaceholders bool
 	closed               bool
+	openOCI8Stmts        []*OCI8Stmt
 }
 
 type OCI8Tx struct {
@@ -875,6 +876,10 @@ func (c *OCI8Conn) Close() error {
 		}
 	}
 
+	for _, openOCI8Stmt := range c.openOCI8Stmts {
+		err = openOCI8Stmt.Close()
+	}
+
 	C.OCIHandleFree(
 		c.env,
 		C.OCI_HTYPE_ENV)
@@ -929,6 +934,8 @@ func (c *OCI8Conn) prepare(ctx context.Context, query string) (driver.Stmt, erro
 
 	ss := &OCI8Stmt{c: c, s: s, bp: (**C.OCIBind)(bp), defp: (**C.OCIDefine)(defp)}
 	//runtime.SetFinalizer(ss, (*OCI8Stmt).Close)
+	c.openOCI8Stmts = append(c.openOCI8Stmts, ss)
+
 	return ss, nil
 }
 

--- a/oci8_go18.go
+++ b/oci8_go18.go
@@ -58,7 +58,7 @@ func (s *OCI8Stmt) QueryContext(ctx context.Context, args []driver.NamedValue) (
 	for i, nv := range args {
 		list[i] = toNamedValue(nv)
 	}
-	return s.query(ctx, list)
+	return s.query(ctx, list, false)
 }
 
 // ExecContext implement ExecerContext.
@@ -81,9 +81,9 @@ func (c *OCI8Conn) CheckNamedValue(nv *driver.NamedValue) error {
 
 func handleOutput(v interface{}) (outValue, bool) {
 	if out, ok := v.(sql.Out); ok {
-		return outValue {
+		return outValue{
 			Dest: out.Dest,
-			In: out.In,
+			In:   out.In,
 		}, true
 	}
 	return outValue{}, false


### PR DESCRIPTION
This pull request avoids  runtime.SetFinalizer calls and thus avoids potential problems such as "A finalizer may run as soon as an object becomes unreachable" ...