### PR TITLE
Allow connection to an ASM instance with sysasm

### DIFF
--- a/oci8.go
+++ b/oci8.go
@@ -532,6 +532,8 @@ func ParseDSN(dsnString string) (dsn *DSN, err error) {
 			switch v[0] {
 			case "SYSDBA", "sysdba":
 				dsn.operationMode = C.OCI_SYSDBA
+			case "SYSASM", "sysasm":
+				dsn.operationMode = C.OCI_SYSASM
 			case "SYSOPER", "sysoper":
 				dsn.operationMode = C.OCI_SYSOPER
 			default:


### PR DESCRIPTION
Adding the privilege 'sysasm' by name in order to be compliant with the
sqlplus client side. In the connect itself, you can also connect with
'sysdba' to an ASM instance, the OCI8 layer will handle this correctly.