### PR TITLE
Fix Ping() for older versions of Oracle (<10.2?)

### DIFF
--- a/oci8.go
+++ b/oci8.go
@@ -660,7 +660,7 @@ func (c *OCI8Conn) ping(ctx context.Context) error {
 	if rv != C.OCI_SUCCESS {
 		if strings.HasPrefix(ociGetError(rv, c.err).Error(), "ORA-01010") {
 			// Older versions of Oracle do not support ping,
-			// but a reponse of "ORA-01010: invalid OCI operation" confirms conectivity.
+			// but a reponse of "ORA-01010: invalid OCI operation" confirms connectivity.
 			// See https://github.com/rana/ora/issues/224
 			return nil
 		}

--- a/oci8.go
+++ b/oci8.go
@@ -658,6 +658,12 @@ func (c *OCI8Conn) ping(ctx context.Context) error {
 		(*C.OCIError)(c.err),
 		C.OCI_DEFAULT)
 	if rv != C.OCI_SUCCESS {
+		if strings.HasPrefix(ociGetError(rv, c.err).Error(), "ORA-01010") {
+			// Older versions of Oracle do not support ping,
+			// but a reponse of "ORA-01010: invalid OCI operation" confirms conectivity.
+			// See https://github.com/rana/ora/issues/224
+			return nil
+		}
 		return errors.New("ping failed")
 	}
 	return nil


### PR DESCRIPTION
Ping() fails against a legacy Oracle 8i database.
However, OCIPing returns an error of "ORA-01010: invalid OCI operation", thus confirming that the connection is active.
A similar fix can be found at https://github.com/rana/ora/issues/224