### PR TITLE
questionph: error msg match option

### DIFF
--- a/oci8.go
+++ b/oci8.go
@@ -94,7 +94,7 @@ func ParseDSN(dsnString string) (dsn *DSN, err error) {
 		case "questionph":
 			dsn.enableQMPlaceholders, err = strconv.ParseBool(v[0])
 			if err != nil {
-				return nil, fmt.Errorf("Invalid questionpm: %v", v[0])
+				return nil, fmt.Errorf("Invalid questionph: %v", v[0])
 			}
 		case "prefetch_rows":
 			z, err := strconv.ParseUint(v[0], 10, 32)


### PR DESCRIPTION
I recently updated this module and had a curious error message.

`
Invalid questionpm: YES
`

I understand that `questionph=YES` is now invalid because this is using strconv.ParseBool. That is fine.

The error message should match the option name that is passed.

