### PR TITLE
Added Statement caching

### DIFF
--- a/connection.go
+++ b/connection.go
@@ -124,11 +124,10 @@ func (conn *Conn) PrepareContext(ctx context.Context, query string) (driver.Stmt
 			return nil, conn.getError(rv)
 		}
 
-		return &Stmt{conn: conn, stmt: *stmt, ctx: ctx}, nil
+		return &Stmt{conn: conn, stmt: *stmt, ctx: ctx, releaseMode: C.ub4(C.OCI_DEFAULT)}, nil
 	}
 
-	var rv C.sword
-	if rv = C.OCIStmtPrepare2(
+	if rv := C.OCIStmtPrepare2(
 		conn.svc,                // service context handle
 		stmt,                    // pointer to the statement handle returned
 		conn.errHandle,          // error handle
@@ -143,7 +142,7 @@ func (conn *Conn) PrepareContext(ctx context.Context, query string) (driver.Stmt
 		return nil, conn.getError(rv)
 	}
 
-	return &Stmt{conn: conn, stmt: *stmt, ctx: ctx, cacheKey: query, cacheHit: rv == C.OCI_SUCCESS}, nil
+	return &Stmt{conn: conn, stmt: *stmt, ctx: ctx, releaseMode: C.ub4(C.OCI_DEFAULT), cacheKey: query}, nil
 }
 
 // Begin starts a transaction

--- a/connection.go
+++ b/connection.go
@@ -92,33 +92,30 @@ func (conn *Conn) Prepare(query string) (driver.Stmt, error) {
 
 // PrepareContext prepares a query with context
 func (conn *Conn) PrepareContext(ctx context.Context, query string) (driver.Stmt, error) {
-	if ctx.Err() != nil {
-		return nil, ctx.Err()
-	}
-
 	if conn.enableQMPlaceholders {
 		query = placeholders(query)
 	}
 
+	queryP := cString(query)
+	defer C.free(unsafe.Pointer(queryP))
 	var stmtTemp *C.OCIStmt
 	stmt := &stmtTemp
-	queryP := cString(query)
-	queryLen := C.ub4(len(query))
+
+	if ctx.Err() != nil {
+		return nil, ctx.Err()
+	}
 
 	done := make(chan struct{})
 	go conn.ociBreakDone(ctx, done)
 	defer func() { close(done) }()
 
 	if conn.stmtCacheSize == 0 {
-		// we only free the memory when caching is disabled. This is because we store the the cache key and will free it in the release
-		defer C.free(unsafe.Pointer(queryP))
-
 		if rv := C.OCIStmtPrepare2(
 			conn.svc,                // service context handle
 			stmt,                    // pointer to the statement handle returned
 			conn.errHandle,          // error handle
 			queryP,                  // statement text
-			queryLen,                // statement text length
+			C.ub4(len(query)),       // statement text length
 			nil,                     // key to be used for searching the statement in the statement cache
 			C.ub4(0),                // length of the key
 			C.ub4(C.OCI_NTV_SYNTAX), // syntax - OCI_NTV_SYNTAX: syntax depends upon the version of the server
@@ -130,14 +127,15 @@ func (conn *Conn) PrepareContext(ctx context.Context, query string) (driver.Stmt
 		return &Stmt{conn: conn, stmt: *stmt, ctx: ctx}, nil
 	}
 
-	if rv := C.OCIStmtPrepare2(
+	var rv C.sword
+	if rv = C.OCIStmtPrepare2(
 		conn.svc,                // service context handle
 		stmt,                    // pointer to the statement handle returned
 		conn.errHandle,          // error handle
 		queryP,                  // statement text
-		queryLen,                // statement text length
+		C.ub4(len(query)),       // statement text length
 		queryP,                  // key to be used for searching the statement in the statement cache
-		queryLen,                // length of the key
+		C.ub4(len(query)),       // length of the key
 		C.ub4(C.OCI_NTV_SYNTAX), // syntax - OCI_NTV_SYNTAX: syntax depends upon the version of the server
 		C.ub4(C.OCI_DEFAULT),    // mode
 	); rv != C.OCI_SUCCESS && rv != C.OCI_SUCCESS_WITH_INFO {
@@ -145,7 +143,7 @@ func (conn *Conn) PrepareContext(ctx context.Context, query string) (driver.Stmt
 		return nil, conn.getError(rv)
 	}
 
-	return &Stmt{conn: conn, stmt: *stmt, ctx: ctx, cacheKey: queryP, cacheKeyLen: queryLen}, nil
+	return &Stmt{conn: conn, stmt: *stmt, ctx: ctx, cacheKey: query, cacheHit: rv == C.OCI_SUCCESS}, nil
 }
 
 // Begin starts a transaction

--- a/connection.go
+++ b/connection.go
@@ -124,7 +124,7 @@ func (conn *Conn) PrepareContext(ctx context.Context, query string) (driver.Stmt
 			return nil, conn.getError(rv)
 		}
 
-		return &Stmt{conn: conn, stmt: *stmt, ctx: ctx, releaseMode: C.ub4(C.OCI_DEFAULT)}, nil
+		return &Stmt{conn: conn, stmt: *stmt, ctx: ctx, releaseMode: C.OCI_DEFAULT}, nil
 	}
 
 	if rv := C.OCIStmtPrepare2(
@@ -142,7 +142,7 @@ func (conn *Conn) PrepareContext(ctx context.Context, query string) (driver.Stmt
 		return nil, conn.getError(rv)
 	}
 
-	return &Stmt{conn: conn, stmt: *stmt, ctx: ctx, releaseMode: C.ub4(C.OCI_DEFAULT), cacheKey: query}, nil
+	return &Stmt{conn: conn, stmt: *stmt, ctx: ctx, releaseMode: C.OCI_DEFAULT, cacheKey: query}, nil
 }
 
 // Begin starts a transaction

--- a/globals.go
+++ b/globals.go
@@ -82,12 +82,13 @@ type (
 
 	// Stmt is Oracle statement
 	Stmt struct {
-		conn        *Conn
-		stmt        *C.OCIStmt
-		closed      bool
-		ctx         context.Context
-		cacheKey    *C.OraText
-		cacheKeyLen C.ub4
+		conn     *Conn
+		stmt     *C.OCIStmt
+		closed   bool
+		ctx      context.Context
+		cacheKey string // if statement caching is enabled, this is the key for this statement into the cache
+		cacheHit bool   // if statement caching is enabled, this will be true when we get a cache hit for a given
+		// query. False if it was a miss, or caching is not enabled.
 	}
 
 	// Rows is Oracle rows

--- a/globals.go
+++ b/globals.go
@@ -82,14 +82,12 @@ type (
 
 	// Stmt is Oracle statement
 	Stmt struct {
-		conn     *Conn
-		stmt     *C.OCIStmt
-		closed   bool
-		ctx      context.Context
-		cacheKey string // if statement caching is enabled, this is the key for this statement into the cache
-		cacheHit bool   // if statement caching is enabled, this will be true when we get a cache hit for a given
-		// query. False if it was a miss, or caching is not enabled.
-		deleteCacheEntry bool
+		conn        *Conn
+		stmt        *C.OCIStmt
+		closed      bool
+		ctx         context.Context
+		cacheKey    string // if statement caching is enabled, this is the key for this statement into the cache
+		releaseMode C.ub4
 	}
 
 	// Rows is Oracle rows

--- a/globals.go
+++ b/globals.go
@@ -40,6 +40,7 @@ type (
 		transactionMode      C.ub4
 		enableQMPlaceholders bool
 		operationMode        C.ub4
+		stmtCacheSize        C.ub4
 	}
 
 	// DriverStruct is Oracle driver struct
@@ -66,6 +67,7 @@ type (
 		prefetchMemory       C.ub4
 		transactionMode      C.ub4
 		operationMode        C.ub4
+		stmtCacheSize        C.ub4
 		inTransaction        bool
 		enableQMPlaceholders bool
 		closed               bool
@@ -80,10 +82,12 @@ type (
 
 	// Stmt is Oracle statement
 	Stmt struct {
-		conn   *Conn
-		stmt   *C.OCIStmt
-		closed bool
-		ctx    context.Context
+		conn        *Conn
+		stmt        *C.OCIStmt
+		closed      bool
+		ctx         context.Context
+		cacheKey    *C.OraText
+		cacheKeyLen C.ub4
 	}
 
 	// Rows is Oracle rows

--- a/globals.go
+++ b/globals.go
@@ -89,6 +89,7 @@ type (
 		cacheKey string // if statement caching is enabled, this is the key for this statement into the cache
 		cacheHit bool   // if statement caching is enabled, this will be true when we get a cache hit for a given
 		// query. False if it was a miss, or caching is not enabled.
+		deleteCacheEntry bool
 	}
 
 	// Rows is Oracle rows

--- a/oci8_sql_go_113_test.go
+++ b/oci8_sql_go_113_test.go
@@ -49,16 +49,18 @@ func TestStatementCaching(t *testing.T) {
 
 	rawStmt := stmt.(*Stmt)
 	if rawStmt.cacheKey != "select ?, ?, ? from dual" {
-		closeStatement(t, stmt)
+		err := stmt.Close()
+		if err != nil {
+			t.Fatal("stmt close error:", err)
+		}
 		t.Fatalf("cacheKey not equal: expected %s, but got %s", "select ?, ?, ? from dual", rawStmt.cacheKey)
-	}
-	if rawStmt.cacheHit {
-		closeStatement(t, stmt)
-		t.Fatalf("should not have been a cache hit the first time the statement is prepared")
 	}
 
 	// closing the statement should put the statement into the cache
-	closeStatement(t, stmt)
+	err = stmt.Close()
+	if err != nil {
+		t.Fatal("stmt close error:", err)
+	}
 
 	ctx, cancel = context.WithTimeout(context.Background(), TestContextTimeout)
 	stmt, err = rawConn.PrepareContext(ctx, "select ?, ?, ? from dual")
@@ -69,12 +71,14 @@ func TestStatementCaching(t *testing.T) {
 
 	rawStmt = stmt.(*Stmt)
 	if rawStmt.cacheKey != "select ?, ?, ? from dual" {
-		closeStatement(t, stmt)
+		err := stmt.Close()
+		if err != nil {
+			t.Fatal("stmt close error:", err)
+		}
 		t.Fatalf("cacheKey not equal: expected %s, but got %s", "select ?, ?, ? from dual", rawStmt.cacheKey)
 	}
-	if !rawStmt.cacheHit {
-		closeStatement(t, stmt)
-		t.Fatalf("should have been a cache hit the second time the statement is prepared")
+	err = stmt.Close()
+	if err != nil {
+		t.Fatal("stmt close error:", err)
 	}
-	closeStatement(t, stmt)
 }

--- a/oci8_sql_go_113_test.go
+++ b/oci8_sql_go_113_test.go
@@ -1,0 +1,80 @@
+// +build go1.13
+
+package oci8
+
+import (
+	"context"
+	"testing"
+)
+
+// TestStatementCaching tests to ensure statement caching is working
+func TestStatementCaching(t *testing.T) {
+	if TestDisableDatabase {
+		t.SkipNow()
+	}
+
+	t.Parallel()
+
+	var err error
+
+	db := testGetDB("?stmt_cache_size=10")
+	if db == nil {
+		t.Fatal("db is null")
+	}
+
+	defer func() {
+		err = db.Close()
+		if err != nil {
+			t.Fatal("db close error:", err)
+		}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), TestContextTimeout)
+	conn, err := db.Conn(ctx)
+	cancel()
+	// we need to get access to the raw connection so we can access the different fields on the oci8.Stmt
+	var rawConn *Conn
+	// NOTE that conn.Raw() is only available with Go >= 1.13
+	_ = conn.Raw(func(driverConn interface{}) error {
+		rawConn = driverConn.(*Conn)
+		return nil
+	})
+
+	ctx, cancel = context.WithTimeout(context.Background(), TestContextTimeout)
+	stmt, err := rawConn.PrepareContext(ctx, "select ?, ?, ? from dual")
+	cancel()
+	if err != nil {
+		t.Fatal("prepare error:", err)
+	}
+
+	rawStmt := stmt.(*Stmt)
+	if rawStmt.cacheKey != "select ?, ?, ? from dual" {
+		closeStatement(t, stmt)
+		t.Fatalf("cacheKey not equal: expected %s, but got %s", "select ?, ?, ? from dual", rawStmt.cacheKey)
+	}
+	if rawStmt.cacheHit {
+		closeStatement(t, stmt)
+		t.Fatalf("should not have been a cache hit the first time the statement is prepared")
+	}
+
+	// closing the statement should put the statement into the cache
+	closeStatement(t, stmt)
+
+	ctx, cancel = context.WithTimeout(context.Background(), TestContextTimeout)
+	stmt, err = rawConn.PrepareContext(ctx, "select ?, ?, ? from dual")
+	cancel()
+	if err != nil {
+		t.Fatal("prepare error:", err)
+	}
+
+	rawStmt = stmt.(*Stmt)
+	if rawStmt.cacheKey != "select ?, ?, ? from dual" {
+		closeStatement(t, stmt)
+		t.Fatalf("cacheKey not equal: expected %s, but got %s", "select ?, ?, ? from dual", rawStmt.cacheKey)
+	}
+	if !rawStmt.cacheHit {
+		closeStatement(t, stmt)
+		t.Fatalf("should have been a cache hit the second time the statement is prepared")
+	}
+	closeStatement(t, stmt)
+}

--- a/oci8_sql_string_test.go
+++ b/oci8_sql_string_test.go
@@ -1194,7 +1194,7 @@ func TestSelectDualString(t *testing.T) {
 	}
 
 	var result [][]interface{}
-	result, err = testGetRows(stmt, nil)
+	result, err = testGetRows(t, stmt, nil)
 	if err != nil {
 		t.Fatal("get rows error:", err)
 	}
@@ -1709,7 +1709,7 @@ func TestDestructiveString(t *testing.T) {
 	}
 
 	var result [][]interface{}
-	result, err = testGetRows(stmt, nil)
+	result, err = testGetRows(t, stmt, nil)
 	if err != nil {
 		t.Fatal("get rows error:", err)
 	}

--- a/oci8_sql_string_test.go
+++ b/oci8_sql_string_test.go
@@ -1194,7 +1194,7 @@ func TestSelectDualString(t *testing.T) {
 	}
 
 	var result [][]interface{}
-	result, err = testGetRows(t, stmt, nil)
+	result, err = testGetRows(stmt, nil)
 	if err != nil {
 		t.Fatal("get rows error:", err)
 	}
@@ -1709,7 +1709,7 @@ func TestDestructiveString(t *testing.T) {
 	}
 
 	var result [][]interface{}
-	result, err = testGetRows(t, stmt, nil)
+	result, err = testGetRows(stmt, nil)
 	if err != nil {
 		t.Fatal("get rows error:", err)
 	}

--- a/oci8_sql_test.go
+++ b/oci8_sql_test.go
@@ -1492,7 +1492,7 @@ func TestSelectParallelWithStatementCaching(t *testing.T) {
 		go func(num int) {
 			defer waitGroup.Done()
 
-			selectNumFromDual(t, db, num)
+			selectNumFromDual(t, db, float64(num))
 		}(i)
 	}
 
@@ -1500,7 +1500,7 @@ func TestSelectParallelWithStatementCaching(t *testing.T) {
 }
 
 // selectNumFromDual will execute a "select :1 from dual" where the parameter is the num param of this function
-func selectNumFromDual(t testing.TB, db *sql.DB, num int) {
+func selectNumFromDual(t testing.TB, db *sql.DB, num float64) {
 	ctx, cancel := context.WithTimeout(context.Background(), TestContextTimeout)
 	stmt, err := db.PrepareContext(ctx, "select :1 from dual")
 	cancel()
@@ -1534,7 +1534,7 @@ func selectNumFromDual(t testing.TB, db *sql.DB, num int) {
 	if !ok {
 		t.Fatal("result not float64")
 	}
-	if data != float64(num) {
+	if data != num {
 		t.Fatal("result not equal to:", num)
 	}
 }
@@ -1544,7 +1544,7 @@ func BenchmarkSelectNoCaching(b *testing.B) {
 		b.SkipNow()
 	}
 	for i := 0; i < b.N; i++ {
-		selectNumFromDual(b, TestDB, i)
+		selectNumFromDual(b, TestDB, float64(i))
 	}
 }
 
@@ -1569,7 +1569,7 @@ func BenchmarkSelectWithCaching(b *testing.B) {
 
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
-		selectNumFromDual(b, db, i)
+		selectNumFromDual(b, db, float64(i))
 	}
 }
 

--- a/oci8_sql_test.go
+++ b/oci8_sql_test.go
@@ -66,7 +66,7 @@ func testExecQuery(t *testing.T, query string, args []interface{}) {
 }
 
 // testGetRows runs a statement and returns the rows as [][]interface{}
-func testGetRows(stmt *sql.Stmt, args []interface{}) ([][]interface{}, error) {
+func testGetRows(t testing.TB, stmt *sql.Stmt, args []interface{}) ([][]interface{}, error) {
 	// get rows
 	ctx, cancel := context.WithTimeout(context.Background(), TestContextTimeout)
 	defer cancel()
@@ -272,7 +272,7 @@ func testRunQueryResults(t *testing.T, queryResults testQueryResults) {
 
 // testRunQueryResult runs a single testQueryResults test
 func testRunQueryResult(t *testing.T, queryResult testQueryResult, query string, stmt *sql.Stmt) {
-	result, err := testGetRows(stmt, queryResult.args)
+	result, err := testGetRows(t, stmt, queryResult.args)
 	if err != nil {
 		t.Errorf("get rows error: %v - query: %v", err, query)
 		return
@@ -402,12 +402,36 @@ func TestSelectParallel(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		go func(num int) {
 			defer waitGroup.Done()
-			doSelect(t, stmt, num)
+			var result [][]interface{}
+			result, err = testGetRows(t, stmt, []interface{}{num})
+			if err != nil {
+				t.Fatal("get rows error:", err)
+			}
+			if result == nil {
+				t.Fatal("result is nil")
+			}
+			if len(result) != 1 {
+				t.Fatal("len result not equal to 1")
+			}
+			if len(result[0]) != 1 {
+				t.Fatal("len result[0] not equal to 1")
+			}
+			data, ok := result[0][0].(float64)
+			if !ok {
+				t.Fatal("result not float64")
+			}
+			if data != float64(num) {
+				t.Fatal("result not equal to:", num)
+			}
 		}(i)
 	}
 
 	waitGroup.Wait()
-	closeStatement(t, stmt)
+
+	err = stmt.Close()
+	if err != nil {
+		t.Fatal("stmt close error:", err)
+	}
 }
 
 // TestContextTimeoutBreak checks that ExecContext timeout works
@@ -448,7 +472,10 @@ end;
 		t.Fatalf("stmt exec - expected: %v - received: %v", expected, err)
 	}
 
-	closeStatement(t, stmt)
+	err = stmt.Close()
+	if err != nil {
+		t.Fatal("stmt close error:", err)
+	}
 
 	// query
 	ctx, cancel = context.WithTimeout(context.Background(), TestContextTimeout)
@@ -465,7 +492,10 @@ end;
 		t.Fatalf("stmt query - expected: %v - received: %v", expected, err)
 	}
 
-	closeStatement(t, stmt)
+	err = stmt.Close()
+	if err != nil {
+		t.Fatal("stmt close error:", err)
+	}
 }
 
 // TestDestructiveTransaction tests a transaction
@@ -570,7 +600,7 @@ func TestDestructiveTransaction(t *testing.T) {
 		t.Fatal("prepare error:", err)
 	}
 	var rows [][]interface{}
-	rows, err = testGetRows(stmt, []interface{}{1})
+	rows, err = testGetRows(t, stmt, []interface{}{1})
 	if err != nil {
 		t.Fatal("get rows error:", err)
 	}
@@ -609,7 +639,7 @@ func TestDestructiveTransaction(t *testing.T) {
 	}
 
 	// tx1 with rows A = 4
-	rows, err = testGetRows(stmt, []interface{}{4})
+	rows, err = testGetRows(t, stmt, []interface{}{4})
 	if err != nil {
 		t.Fatal("get rows error:", err)
 	}
@@ -652,7 +682,7 @@ func TestDestructiveTransaction(t *testing.T) {
 	if err != nil {
 		t.Fatal("prepare error:", err)
 	}
-	rows, err = testGetRows(stmt, []interface{}{1})
+	rows, err = testGetRows(t, stmt, []interface{}{1})
 	if err != nil {
 		t.Fatal("get rows error:", err)
 	}
@@ -691,7 +721,7 @@ func TestDestructiveTransaction(t *testing.T) {
 	}
 
 	// tx2 with rows A = 4
-	rows, err = testGetRows(stmt, []interface{}{4})
+	rows, err = testGetRows(t, stmt, []interface{}{4})
 	if err != nil {
 		t.Fatal("get rows error:", err)
 	}
@@ -793,7 +823,10 @@ func TestInsertRowid(t *testing.T) {
 		t.Fatal("exec error:", err)
 	}
 
-	closeStatement(t, stmt)
+	err = stmt.Close()
+	if err != nil {
+		t.Fatal("stmt close error:", err)
+	}
 
 	// drop table
 	defer func() {
@@ -813,7 +846,10 @@ func TestInsertRowid(t *testing.T) {
 			t.Fatal("exec error:", err)
 		}
 
-		closeStatement(t, stmt)
+		err = stmt.Close()
+		if err != nil {
+			t.Fatal("stmt close error:", err)
+		}
 	}()
 
 	// insert into table
@@ -1108,7 +1144,7 @@ func TestQuestionMark(t *testing.T) {
 	}
 
 	var result [][]interface{}
-	result, err = testGetRows(stmt, []interface{}{1, 2.25, "three"})
+	result, err = testGetRows(t, stmt, []interface{}{1, 2.25, "three"})
 	if err != nil {
 		t.Fatal("get rows error:", err)
 	}
@@ -1172,7 +1208,10 @@ func BenchmarkSimpleInsert(b *testing.B) {
 		b.Fatal("exec error:", err)
 	}
 
-	closeStatement(b, stmt)
+	err = stmt.Close()
+	if err != nil {
+		b.Fatal("stmt close error:", err)
+	}
 
 	// drop table
 	defer func() {
@@ -1192,7 +1231,10 @@ func BenchmarkSimpleInsert(b *testing.B) {
 			b.Fatal("exec error:", err)
 		}
 
-		closeStatement(b, stmt)
+		err = stmt.Close()
+		if err != nil {
+			b.Fatal("stmt close error:", err)
+		}
 	}()
 
 	// insert into table
@@ -1250,7 +1292,10 @@ func benchmarkSelectSetup(b *testing.B) {
 	// enable drop table in TestMain
 	benchmarkSelectTableCreated = true
 
-	closeStatement(b, stmt)
+	err = stmt.Close()
+	if err != nil {
+		b.Fatal("stmt close error:", err)
+	}
 
 	// insert into table
 	query = "insert into " + tableName + ` ( A, B, C, D, E, F, G, H )
@@ -1440,24 +1485,22 @@ func TestSelectParallelWithStatementCaching(t *testing.T) {
 		t.Fatal("db is null")
 	}
 
-	doParallelSelect(t, db)
-}
-
-func doParallelSelect(t *testing.T, db *sql.DB) {
 	var waitGroup sync.WaitGroup
 	waitGroup.Add(50)
 
 	for i := 0; i < 50; i++ {
 		go func(num int) {
 			defer waitGroup.Done()
-			doPrepareAndSelect(t, db, num)
+
+			selectNumFromDual(t, db, num)
 		}(i)
 	}
 
 	waitGroup.Wait()
 }
 
-func doPrepareAndSelect(t fataler, db *sql.DB, num int) {
+// selectNumFromDual will execute a "select :1 from dual" where the parameter is the num param of this function
+func selectNumFromDual(t testing.TB, db *sql.DB, num int) {
 	ctx, cancel := context.WithTimeout(context.Background(), TestContextTimeout)
 	stmt, err := db.PrepareContext(ctx, "select :1 from dual")
 	cancel()
@@ -1466,11 +1509,34 @@ func doPrepareAndSelect(t fataler, db *sql.DB, num int) {
 	}
 	defer func() {
 		if stmt != nil {
-			closeStatement(t, stmt)
+			err := stmt.Close()
+			if err != nil {
+				t.Fatal("stmt close error:", err)
+			}
 		}
 	}()
 
-	doSelect(t, stmt, num)
+	var result [][]interface{}
+	result, err = testGetRows(t, stmt, []interface{}{num})
+	if err != nil {
+		t.Fatal("get rows error:", err)
+	}
+	if result == nil {
+		t.Fatal("result is nil")
+	}
+	if len(result) != 1 {
+		t.Fatal("len result not equal to 1")
+	}
+	if len(result[0]) != 1 {
+		t.Fatal("len result[0] not equal to 1")
+	}
+	data, ok := result[0][0].(float64)
+	if !ok {
+		t.Fatal("result not float64")
+	}
+	if data != float64(num) {
+		t.Fatal("result not equal to:", num)
+	}
 }
 
 func BenchmarkSelectNoCaching(b *testing.B) {
@@ -1478,7 +1544,7 @@ func BenchmarkSelectNoCaching(b *testing.B) {
 		b.SkipNow()
 	}
 	for i := 0; i < b.N; i++ {
-		doPrepareAndSelect(b, TestDB, i)
+		selectNumFromDual(b, TestDB, i)
 	}
 }
 
@@ -1503,7 +1569,7 @@ func BenchmarkSelectWithCaching(b *testing.B) {
 
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
-		doPrepareAndSelect(b, db, i)
+		selectNumFromDual(b, db, i)
 	}
 }
 
@@ -1564,44 +1630,5 @@ func BenchmarkPrefetchR1000M0(b *testing.B) {
 
 	for n := 0; n < b.N; {
 		benchmarkPrefetchSelect(b, 1000, 0, &n)
-	}
-}
-
-type fataler interface {
-	Fatal(args ...interface{})
-}
-
-func doSelect(t fataler, stmt *sql.Stmt, num int) {
-	var result [][]interface{}
-	result, err := testGetRows(stmt, []interface{}{num})
-	if err != nil {
-		t.Fatal("get rows error:", err)
-	}
-	if result == nil {
-		t.Fatal("result is nil")
-	}
-	if len(result) != 1 {
-		t.Fatal("len result not equal to 1")
-	}
-	if len(result[0]) != 1 {
-		t.Fatal("len result[0] not equal to 1")
-	}
-	data, ok := result[0][0].(float64)
-	if !ok {
-		t.Fatal("result not float64")
-	}
-	if data != float64(num) {
-		t.Fatal("result not equal to:", num)
-	}
-}
-
-type closer interface {
-	Close() error
-}
-
-func closeStatement(t fataler, stmt closer) {
-	err := stmt.Close()
-	if err != nil {
-		t.Fatal("stmt close error:", err)
 	}
 }

--- a/oci8_test.go
+++ b/oci8_test.go
@@ -185,16 +185,18 @@ func TestParseDSN(t *testing.T) {
 
 	const prefetchRows = 0
 	const prefetchMemory = 4096
+	const stmtCacheSize = 0
 
 	var dsnTests = []struct {
 		dsnString   string
 		expectedDSN *DSN
 	}{
-		{"oracle://xxmc:xxmc@107.20.30.169:1521/ORCL?loc=America%2FPhoenix", &DSN{Username: "xxmc", Password: "xxmc", Connect: "107.20.30.169:1521/ORCL", prefetchRows: prefetchRows, prefetchMemory: prefetchMemory, timeLocation: timeLocations[5]}},
-		{"xxmc/xxmc@107.20.30.169:1521/ORCL?loc=America%2FPhoenix", &DSN{Username: "xxmc", Password: "xxmc", Connect: "107.20.30.169:1521/ORCL", prefetchRows: prefetchRows, prefetchMemory: prefetchMemory, timeLocation: timeLocations[5]}},
-		{"sys/syspwd@107.20.30.169:1521/ORCL?loc=America%2FPhoenix&as=sysdba", &DSN{Username: "sys", Password: "syspwd", Connect: "107.20.30.169:1521/ORCL", prefetchRows: prefetchRows, prefetchMemory: prefetchMemory, timeLocation: timeLocations[5], operationMode: 0x00000002}}, // with operationMode: 0x00000002 = C.OCI_SYDBA
-		{"xxmc/xxmc@107.20.30.169:1521/ORCL", &DSN{Username: "xxmc", Password: "xxmc", Connect: "107.20.30.169:1521/ORCL", prefetchRows: prefetchRows, prefetchMemory: prefetchMemory, timeLocation: time.UTC}},
-		{"xxmc/xxmc@107.20.30.169/ORCL", &DSN{Username: "xxmc", Password: "xxmc", Connect: "107.20.30.169/ORCL", prefetchRows: prefetchRows, prefetchMemory: prefetchMemory, timeLocation: time.UTC}},
+		{"oracle://xxmc:xxmc@107.20.30.169:1521/ORCL?loc=America%2FPhoenix", &DSN{Username: "xxmc", Password: "xxmc", Connect: "107.20.30.169:1521/ORCL", prefetchRows: prefetchRows, prefetchMemory: prefetchMemory, stmtCacheSize: stmtCacheSize, timeLocation: timeLocations[5]}},
+		{"xxmc/xxmc@107.20.30.169:1521/ORCL?loc=America%2FPhoenix", &DSN{Username: "xxmc", Password: "xxmc", Connect: "107.20.30.169:1521/ORCL", prefetchRows: prefetchRows, prefetchMemory: prefetchMemory, stmtCacheSize: stmtCacheSize, timeLocation: timeLocations[5]}},
+		{"sys/syspwd@107.20.30.169:1521/ORCL?loc=America%2FPhoenix&as=sysdba", &DSN{Username: "sys", Password: "syspwd", Connect: "107.20.30.169:1521/ORCL", prefetchRows: prefetchRows, prefetchMemory: prefetchMemory, stmtCacheSize: stmtCacheSize, timeLocation: timeLocations[5], operationMode: 0x00000002}}, // with operationMode: 0x00000002 = C.OCI_SYDBA
+		{"xxmc/xxmc@107.20.30.169:1521/ORCL", &DSN{Username: "xxmc", Password: "xxmc", Connect: "107.20.30.169:1521/ORCL", prefetchRows: prefetchRows, prefetchMemory: prefetchMemory, stmtCacheSize: stmtCacheSize, timeLocation: time.UTC}},
+		{"xxmc/xxmc@107.20.30.169/ORCL", &DSN{Username: "xxmc", Password: "xxmc", Connect: "107.20.30.169/ORCL", prefetchRows: prefetchRows, prefetchMemory: prefetchMemory, stmtCacheSize: stmtCacheSize, timeLocation: time.UTC}},
+		{"xxmc/xxmc@107.20.30.169/ORCL?stmt_cache_size=50", &DSN{Username: "xxmc", Password: "xxmc", Connect: "107.20.30.169/ORCL", prefetchRows: prefetchRows, prefetchMemory: prefetchMemory, stmtCacheSize: 50, timeLocation: time.UTC}},
 	}
 
 	for _, tt := range dsnTests {

--- a/rows.go
+++ b/rows.go
@@ -202,7 +202,7 @@ func (rows *Rows) Next(dest []driver.Value) error {
 		// SQLT_RSET - ref cursor
 		case C.SQLT_RSET:
 			stmtP := (**C.OCIStmt)(rows.defines[i].pbuf)
-			subStmt := &Stmt{conn: rows.stmt.conn, stmt: *stmtP, ctx: rows.stmt.ctx}
+			subStmt := &Stmt{conn: rows.stmt.conn, stmt: *stmtP, ctx: rows.stmt.ctx, releaseMode: C.ub4(C.OCI_DEFAULT)}
 			if rows.defines[i].subDefines == nil {
 				var err error
 				rows.defines[i].subDefines, err = subStmt.makeDefines()

--- a/statement.go
+++ b/statement.go
@@ -1026,9 +1026,9 @@ func (stmt *Stmt) ociStmtExecute(iters C.ub4, mode C.ub4) error {
 		mode,                // The mode: https://docs.oracle.com/cd/E11882_01/appdev.112/e10646/oci17msc001.htm#LNOCI17163
 	)
 
-	if (result != C.OCI_SUCCESS && result != C.OCI_SUCCESS_WITH_INFO) && stmt.cacheKey != "" {
+	if stmt.cacheKey != "" && result != C.OCI_SUCCESS && result != C.OCI_SUCCESS_WITH_INFO {
 		// drop statement from cache for all errors when caching is enabled
-		stmt.releaseMode = C.ub4(C.OCI_STRLS_CACHE_DELETE)
+		stmt.releaseMode = C.OCI_STRLS_CACHE_DELETE
 	}
 
 	return stmt.conn.getError(result)

--- a/statement.go
+++ b/statement.go
@@ -36,17 +36,24 @@ func (stmt *Stmt) Close() error {
 		defer C.free(unsafe.Pointer(cacheKeyP))
 
 		result = C.OCIStmtRelease(
-			stmt.stmt,                 // statement handle
-			stmt.conn.errHandle,       // error handle
-			cacheKeyP,                 // key to be associated with the statement in the cache
-			C.ub4(len(stmt.cacheKey)), // length of the key
-			C.ub4(C.OCI_DEFAULT),      // mode
+			stmt.stmt,                   // statement handle
+			stmt.conn.errHandle,         // error handle
+			cacheKeyP,                   // key to be associated with the statement in the cache
+			C.ub4(len(stmt.cacheKey)),   // length of the key
+			stmt.determineReleaseMode(), // mode
 		)
 	}
 
 	stmt.stmt = nil
 
 	return stmt.conn.getError(result)
+}
+
+func (stmt *Stmt) determineReleaseMode() C.ub4 {
+	if stmt.deleteCacheEntry {
+		return C.ub4(C.OCI_STRLS_CACHE_DELETE)
+	}
+	return C.ub4(C.OCI_DEFAULT)
 }
 
 // NumInput returns the number of input
@@ -1025,6 +1032,11 @@ func (stmt *Stmt) ociStmtExecute(iters C.ub4, mode C.ub4) error {
 		nil,                 // This parameter is optional. If it is supplied, it must point to a descriptor of type OCI_DTYPE_SNAP.
 		mode,                // The mode: https://docs.oracle.com/cd/E11882_01/appdev.112/e10646/oci17msc001.htm#LNOCI17163
 	)
+
+	if result != C.OCI_SUCCESS && stmt.cacheKey != "" {
+		// drop statement from cache for all errors when caching is enabled
+		stmt.deleteCacheEntry = true
+	}
 
 	return stmt.conn.getError(result)
 }

--- a/test.sh
+++ b/test.sh
@@ -53,10 +53,13 @@ sqlplus -L -S "sys/oracle@${DOCKER_IP}:1521 as sysdba" <<SQL
 CREATE USER scott IDENTIFIED BY tiger DEFAULT TABLESPACE users TEMPORARY TABLESPACE temp;
 GRANT connect, resource, create view, create synonym TO scott;
 GRANT execute ON SYS.DBMS_LOCK TO scott;
-/
+alter system set processes=300 scope=spfile;
+shutdown immediate
 
 SQL
 
+echo "starting Oracle"
+/usr/sbin/startup.sh
 
 echo "creating oci8.pc"
 mkdir -p /usr/local/pkg_config


### PR DESCRIPTION
- added parameter `stmt_cache_size` to DSN string. Defaults to zero, disabled. When enabled, it sets the `OCI_ATTR_STMTCACHESIZE` attribute.
- when enabled, passes the query in as the key to `OCIStmtPrepare2`, and also passes the same key to `OCIStmtRelease`. Note that the Java OCI driver uses the query as the cache key as well, hence my choice of using it.
- bumped up the number of processes and sessions in the `test.sh` because it was consistently running out of connections
- also fixed sporadic failures of test for `ORA-01013` but changing to a `!string.Contains` check