### PR TITLE
Fix a memory leakage in getRowid

### DIFF
--- a/statement.go
+++ b/statement.go
@@ -673,6 +673,7 @@ func (stmt *Stmt) getRowid() (string, error) {
 	if err != nil {
 		return "", err
 	}
+	defer C.OCIDescriptorFree(*rowidP, C.OCI_DTYPE_ROWID)
 
 	// OCI_ATTR_ROWID returns the ROWID descriptor allocated with OCIDescriptorAlloc()
 	_, err = stmt.ociAttrGet(*rowidP, C.OCI_ATTR_ROWID)


### PR DESCRIPTION
We believe this PR can fix #405 .

It frees OCI row id descriptor via`OCIDescriptorFree` in`getRowid()`