### PR TITLE
Fix: memory leak in transaction handles

### DIFF
--- a/globals.go
+++ b/globals.go
@@ -63,6 +63,7 @@ type (
 		env                  *C.OCIEnv
 		errHandle            *C.OCIError
 		usrSession           *C.OCISession
+		txHandle             *C.OCITrans
 		prefetchRows         C.ub4
 		prefetchMemory       C.ub4
 		transactionMode      C.ub4

--- a/oci8.go
+++ b/oci8.go
@@ -229,6 +229,10 @@ func (drv *DriverStruct) Open(dsnString string) (driver.Conn, error) {
 					C.OCI_DEFAULT,
 				)
 			}
+			if conn.txHandle != nil {
+				C.OCIHandleFree(unsafe.Pointer(conn.txHandle), C.OCI_HTYPE_TRANS)
+				conn.txHandle = nil
+			}
 			if conn.usrSession != nil {
 				C.OCIHandleFree(unsafe.Pointer(conn.usrSession), C.OCI_HTYPE_SESSION)
 				conn.usrSession = nil
@@ -244,10 +248,6 @@ func (drv *DriverStruct) Open(dsnString string) (driver.Conn, error) {
 			if conn.errHandle != nil {
 				C.OCIHandleFree(unsafe.Pointer(conn.errHandle), C.OCI_HTYPE_ERROR)
 				conn.errHandle = nil
-			}
-			if conn.txHandle != nil {
-				C.OCIHandleFree(unsafe.Pointer(conn.txHandle), C.OCI_HTYPE_TRANS)
-				conn.txHandle = nil
 			}
 			C.OCIHandleFree(unsafe.Pointer(conn.env), C.OCI_HTYPE_ENV)
 		}

--- a/oci8.go
+++ b/oci8.go
@@ -245,6 +245,10 @@ func (drv *DriverStruct) Open(dsnString string) (driver.Conn, error) {
 				C.OCIHandleFree(unsafe.Pointer(conn.errHandle), C.OCI_HTYPE_ERROR)
 				conn.errHandle = nil
 			}
+			if conn.txHandle != nil {
+				C.OCIHandleFree(unsafe.Pointer(conn.txHandle), C.OCI_HTYPE_TRANS)
+				conn.txHandle = nil
+			}
 			C.OCIHandleFree(unsafe.Pointer(conn.env), C.OCI_HTYPE_ENV)
 		}
 	}(&err)
@@ -392,18 +396,17 @@ func (drv *DriverStruct) Open(dsnString string) (driver.Conn, error) {
 	}
 
 	// Create transaction context.
-	trans, _, err := conn.ociHandleAlloc(C.OCI_HTYPE_TRANS, 0)
+	handle, _, err = conn.ociHandleAlloc(C.OCI_HTYPE_TRANS, 0)
 	if err != nil {
 		return nil, fmt.Errorf("allocate transaction handle error: %v", err)
 	}
+	conn.txHandle = (*C.OCITrans)(*handle)
 
 	// Set transaction context attribute of the service context.
-	err = conn.ociAttrSet(unsafe.Pointer(conn.svc), C.OCI_HTYPE_SVCCTX, *trans, 0, C.OCI_ATTR_TRANS)
+	err = conn.ociAttrSet(unsafe.Pointer(conn.svc), C.OCI_HTYPE_SVCCTX, *handle, 0, C.OCI_ATTR_TRANS)
 	if err != nil {
-		C.OCIHandleFree(*trans, C.OCI_HTYPE_TRANS)
 		return nil, err
 	}
-	conn.txHandle = (*C.OCITrans)(*trans)
 
 	conn.transactionMode = dsn.transactionMode
 	conn.prefetchRows = dsn.prefetchRows

--- a/oci8.go
+++ b/oci8.go
@@ -405,7 +405,7 @@ func (drv *DriverStruct) Open(dsnString string) (driver.Conn, error) {
 	// Set transaction context attribute of the service context.
 	err = conn.ociAttrSet(unsafe.Pointer(conn.svc), C.OCI_HTYPE_SVCCTX, *handle, 0, C.OCI_ATTR_TRANS)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("service context attribute set error: %v", err)
 	}
 
 	conn.transactionMode = dsn.transactionMode


### PR DESCRIPTION
Transaction handles are currently allocated upon starting new transactions without proper deallocations of previous handles, which leads to memory leaks. This PR fixes this issue following an approach seen in other OCI driver implementations: a single transaction handle is reused for every new transaction.

**Note**: somehow, one test case (`TestSelectDualString`) seems to have a non-deterministic behavior, as it might occasionally fail even in the `master` branch. All other tests passed normally. We also tested this fix under realistic loads in one of our apps and everything ran smoothly.
