### PR TITLE
Fix test data corruption from in-place append to shared byte slices

### DIFF
--- a/oci8_sql_string_test.go
+++ b/oci8_sql_string_test.go
@@ -2512,21 +2512,21 @@ end;`
 		},
 		{
 			args:    map[string]sql.Out{"string1": {Dest: testByteSlice2000[:1997], In: true}},
-			results: map[string]interface{}{"string1": append(testByteSlice2000[:1997], []byte{120, 121, 122}...)},
+			results: map[string]interface{}{"string1": append(append([]byte{}, testByteSlice2000[:1997]...), 120, 121, 122)},
 		},
 	}
 
 	execResultRawAddEnd4000 := []testExecResult{
 		{
 			args:    map[string]sql.Out{"string1": {Dest: testByteSlice4000[:3997], In: true}},
-			results: map[string]interface{}{"string1": append(testByteSlice4000[:3997], []byte{120, 121, 122}...)},
+			results: map[string]interface{}{"string1": append(append([]byte{}, testByteSlice4000[:3997]...), 120, 121, 122)},
 		},
 	}
 
 	execResultRawAddEnd32767 := []testExecResult{
 		{
 			args:    map[string]sql.Out{"string1": {Dest: testByteSlice32767[:32764], In: true}},
-			results: map[string]interface{}{"string1": append(testByteSlice32767[:32764], []byte{120, 121, 122}...)},
+			results: map[string]interface{}{"string1": append(append([]byte{}, testByteSlice32767[:32764]...), 120, 121, 122)},
 		},
 	}
 


### PR DESCRIPTION
The RAW add-to-end exec test cases build their expected values with append(testByteSliceN[:n-3], "xyz"...). Since the sub-slices have spare capacity, the append writes into the shared global test slices, corrupting the last 3 bytes. Tests that use those globals concurrently (e.g. TestSelectDualString RAW(2000)) then fail depending on timing, as seen in CI on PR #442.

The expected values are now built on a fresh copy. Stacked on #442.