### PR TITLE
Return error from ParseDSN when query parameters are malformed

### DIFF
--- a/oci8.go
+++ b/oci8.go
@@ -73,6 +73,9 @@ func ParseDSN(dsnString string) (dsn *DSN, err error) {
 	dsn.Connect = host
 
 	qp, err := ParseQuery(params)
+	if err != nil {
+		return nil, fmt.Errorf("invalid dsn parameters: %v", err)
+	}
 	for k, v := range qp {
 		switch k {
 		case "loc":


### PR DESCRIPTION
ParseDSN called ParseQuery but never checked its error, so malformed DSN query parameters were silently ignored.