### PR TITLE
Treat OCI_SUCCESS_WITH_INFO as success in query

### DIFF
--- a/statement.go
+++ b/statement.go
@@ -431,7 +431,7 @@ func (stmt *Stmt) query(binds []bindStruct) (driver.Rows, error) {
 	go stmt.conn.ociBreakDone(stmt.ctx, done)
 	err = stmt.ociStmtExecute(iter, mode)
 	close(done)
-	if err != nil {
+	if err != nil && err != ErrOCISuccessWithInfo {
 		return nil, err
 	}
 


### PR DESCRIPTION
OCIStmtExecute returning OCI_SUCCESS_WITH_INFO made query fail while exec already tolerates it. A SELECT that produces a warning should still return rows.