### PR TITLE
Fix zone name for negative timezone offsets with minutes

### DIFF
--- a/oci8.go
+++ b/oci8.go
@@ -444,21 +444,20 @@ func placeholders(sql string) string {
 func timezoneToLocation(hour int64, minute int64) *time.Location {
 	if minute != 0 || hour > 14 || hour < -12 {
 		// create location with FixedZone
-		var name string
-		if hour < 0 {
-			name = strconv.FormatInt(hour, 10) + ":"
-		} else {
-			name = "+" + strconv.FormatInt(hour, 10) + ":"
+		// note that for negative offsets both hour and minute are negative
+		offset := (3600 * int(hour)) + (60 * int(minute))
+		name := "+"
+		if hour < 0 || minute < 0 {
+			name = "-"
+			hour = -hour
+			minute = -minute
 		}
-		if minute == 0 {
-			name += "00"
-		} else {
-			if minute < 10 {
-				name += "0"
-			}
-			name += strconv.FormatInt(minute, 10)
+		name += strconv.FormatInt(hour, 10) + ":"
+		if minute < 10 {
+			name += "0"
 		}
-		return time.FixedZone(name, (3600*int(hour))+(60*int(minute)))
+		name += strconv.FormatInt(minute, 10)
+		return time.FixedZone(name, offset)
 	}
 
 	// use location from timeLocations cache

--- a/oci8_test.go
+++ b/oci8_test.go
@@ -179,6 +179,36 @@ func setupForTesting() int {
 	return 0
 }
 
+// TestTimezoneToLocation tests conversion of a time zone offset to a location
+func TestTimezoneToLocation(t *testing.T) {
+	t.Parallel()
+
+	var tests = []struct {
+		hour           int64
+		minute         int64
+		expectedName   string
+		expectedOffset int
+	}{
+		{9, 0, "Asia/Tokyo", 9 * 3600},
+		{5, 30, "+5:30", 5*3600 + 30*60},
+		{-9, -30, "-9:30", -(9*3600 + 30*60)},
+		{0, -30, "-0:30", -30 * 60},
+		{15, 0, "+15:00", 15 * 3600},
+		{-13, 0, "-13:00", -13 * 3600},
+	}
+
+	for _, tt := range tests {
+		location := timezoneToLocation(tt.hour, tt.minute)
+		if location.String() != tt.expectedName {
+			t.Errorf("timezoneToLocation(%d, %d) name - expected: %v, actual: %v", tt.hour, tt.minute, tt.expectedName, location.String())
+		}
+		_, offset := time.Now().In(location).Zone()
+		if offset != tt.expectedOffset {
+			t.Errorf("timezoneToLocation(%d, %d) offset - expected: %v, actual: %v", tt.hour, tt.minute, tt.expectedOffset, offset)
+		}
+	}
+}
+
 // TestParseDSN tests parsing the DSN
 func TestParseDSN(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
OCIDateTimeGetTimeZoneOffset returns negative minutes for negative offsets, so timezoneToLocation produced zone names like "-9:0-30" for -09:30. The offset seconds were correct; only the name was malformed. Adds a unit test.