### PR TITLE
Fix Connector.Connect to actually open a database connection

### DIFF
--- a/connector.go
+++ b/connector.go
@@ -11,9 +11,13 @@ import (
 
 // NewConnector returns a new database connector
 func NewConnector(hosts ...string) driver.Connector {
-	return &Connector{
+	connector := &Connector{
 		Logger: log.New(ioutil.Discard, "", 0),
 	}
+	if len(hosts) > 0 {
+		connector.dsnString = hosts[0]
+	}
+	return connector
 }
 
 // Driver returns the OCI8 driver
@@ -27,11 +31,14 @@ func (connector *Connector) Connect(ctx context.Context) (driver.Conn, error) {
 		return nil, ctx.Err()
 	}
 
-	conn := &Conn{
-		logger: connector.Logger,
+	connDriver, err := Driver.Open(connector.dsnString)
+	if err != nil {
+		return nil, err
 	}
-	if conn.logger == nil {
-		conn.logger = log.New(ioutil.Discard, "", 0)
+
+	conn := connDriver.(*Conn)
+	if connector.Logger != nil {
+		conn.logger = connector.Logger
 	}
 
 	return conn, nil

--- a/connector_test.go
+++ b/connector_test.go
@@ -1,0 +1,46 @@
+// +build go1.10
+
+package oci8
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+)
+
+// TestConnector tests that a connection from sql.OpenDB with NewConnector works
+func TestConnector(t *testing.T) {
+	if TestDisableDatabase {
+		t.SkipNow()
+	}
+
+	var openString string
+	if len(TestUsername) > 0 {
+		if len(TestPassword) > 0 {
+			openString = TestUsername + "/" + TestPassword + "@"
+		} else {
+			openString = TestUsername + "@"
+		}
+	}
+	openString += TestHostValid
+
+	db := sql.OpenDB(NewConnector(openString))
+	defer db.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), TestContextTimeout)
+	defer cancel()
+
+	err := db.PingContext(ctx)
+	if err != nil {
+		t.Fatal("ping error:", err)
+	}
+
+	var one int64
+	err = db.QueryRowContext(ctx, "select 1 from dual").Scan(&one)
+	if err != nil {
+		t.Fatal("select error:", err)
+	}
+	if one != 1 {
+		t.Fatal("select expected: 1, received:", one)
+	}
+}

--- a/globals.go
+++ b/globals.go
@@ -52,6 +52,8 @@ type (
 	Connector struct {
 		// Logger is used to log connection ping errors
 		Logger *log.Logger
+
+		dsnString string
 	}
 
 	// Conn is Oracle connection


### PR DESCRIPTION
Connector.Connect returned a Conn with no OCI handles, so any connection obtained via sql.OpenDB(NewConnector(...)) crashed on first use. NewConnector also ignored its argument. The connector now stores the DSN and opens a real connection, honoring Connector.Logger. Adds a test using sql.OpenDB.