### PR TITLE
Fix data races and t.Fatal calls in test goroutines

### DIFF
--- a/oci8_sql_number_test.go
+++ b/oci8_sql_number_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"sync"
+	"sync/atomic"
 	"testing"
 )
 
@@ -3611,16 +3612,17 @@ union all select :20 from dual`
 		t.Fatal("prepare error:", err)
 	}
 
-	var hasError bool
+	var hasError int32
 	var waitGroup sync.WaitGroup
 	chanGoLimit := make(chan struct{}, 100)
 	waitGroup.Add(50001)
 	for i := 0; i < 1000020; i += 20 {
 		chanGoLimit <- struct{}{}
 		go func(num int) {
+			var err error
 			for j := 0; j < 100; j++ {
 				ctx, cancel := context.WithTimeout(context.Background(), TestContextTimeout)
-				_, err := stmt.ExecContext(ctx, num, num+1, num+2, num+3, num+4, num+5, num+6, num+7, num+8, num+9,
+				_, err = stmt.ExecContext(ctx, num, num+1, num+2, num+3, num+4, num+5, num+6, num+7, num+8, num+9,
 					num+10, num+11, num+12, num+13, num+14, num+15, num+16, num+17, num+18, num+19)
 				cancel()
 				if err == nil {
@@ -3636,17 +3638,17 @@ union all select :20 from dual`
 			<-chanGoLimit
 			waitGroup.Done()
 			if err != nil {
-				hasError = true
-				t.Fatal("exec error:", err)
+				atomic.StoreInt32(&hasError, 1)
+				t.Error("exec error:", err)
 			}
 		}(i)
-		if hasError {
+		if atomic.LoadInt32(&hasError) != 0 {
 			fmt.Println("has error at", i)
 			break
 		}
 	}
 
-	if !hasError {
+	if atomic.LoadInt32(&hasError) == 0 {
 		fmt.Println("waiting")
 		waitGroup.Wait()
 	}

--- a/oci8_sql_test.go
+++ b/oci8_sql_test.go
@@ -402,26 +402,30 @@ func TestSelectParallel(t *testing.T) {
 	for i := 0; i < 50; i++ {
 		go func(num int) {
 			defer waitGroup.Done()
-			var result [][]interface{}
-			result, err = testGetRows(t, stmt, []interface{}{num})
+			result, err := testGetRows(t, stmt, []interface{}{num})
 			if err != nil {
-				t.Fatal("get rows error:", err)
+				t.Error("get rows error:", err)
+				return
 			}
 			if result == nil {
-				t.Fatal("result is nil")
+				t.Error("result is nil")
+				return
 			}
 			if len(result) != 1 {
-				t.Fatal("len result not equal to 1")
+				t.Error("len result not equal to 1")
+				return
 			}
 			if len(result[0]) != 1 {
-				t.Fatal("len result[0] not equal to 1")
+				t.Error("len result[0] not equal to 1")
+				return
 			}
 			data, ok := result[0][0].(float64)
 			if !ok {
-				t.Fatal("result not float64")
+				t.Error("result not float64")
+				return
 			}
 			if data != float64(num) {
-				t.Fatal("result not equal to:", num)
+				t.Error("result not equal to:", num)
 			}
 		}(i)
 	}
@@ -1577,19 +1581,21 @@ func TestSelectParallelWithStatementCaching(t *testing.T) {
 	waitGroup.Wait()
 }
 
-// selectNumFromDual will execute a "select :1 from dual" where the parameter is the num param of this function
+// selectNumFromDual will execute a "select :1 from dual" where the parameter is the num param of this function.
+// It may be called from a goroutine, so it only uses t.Error, which is safe to call concurrently.
 func selectNumFromDual(t testing.TB, db *sql.DB, num float64) {
 	ctx, cancel := context.WithTimeout(context.Background(), TestContextTimeout)
 	stmt, err := db.PrepareContext(ctx, "select :1 from dual")
 	cancel()
 	if err != nil {
-		t.Fatal("prepare error:", err)
+		t.Error("prepare error:", err)
+		return
 	}
 	defer func() {
 		if stmt != nil {
 			err := stmt.Close()
 			if err != nil {
-				t.Fatal("stmt close error:", err)
+				t.Error("stmt close error:", err)
 			}
 		}
 	}()
@@ -1597,23 +1603,28 @@ func selectNumFromDual(t testing.TB, db *sql.DB, num float64) {
 	var result [][]interface{}
 	result, err = testGetRows(t, stmt, []interface{}{num})
 	if err != nil {
-		t.Fatal("get rows error:", err)
+		t.Error("get rows error:", err)
+		return
 	}
 	if result == nil {
-		t.Fatal("result is nil")
+		t.Error("result is nil")
+		return
 	}
 	if len(result) != 1 {
-		t.Fatal("len result not equal to 1")
+		t.Error("len result not equal to 1")
+		return
 	}
 	if len(result[0]) != 1 {
-		t.Fatal("len result[0] not equal to 1")
+		t.Error("len result[0] not equal to 1")
+		return
 	}
 	data, ok := result[0][0].(float64)
 	if !ok {
-		t.Fatal("result not float64")
+		t.Error("result not float64")
+		return
 	}
 	if data != num {
-		t.Fatal("result not equal to:", num)
+		t.Error("result not equal to:", num)
 	}
 }
 


### PR DESCRIPTION
TestSelectParallel goroutines shared the enclosing err variable (data race, caught by -race) and called t.Fatal from non-test goroutines (flagged by go vet). Same for selectNumFromDual and TestSelectCountLarge, where the exec error check also read the wrong err variable and hasError was accessed without synchronization.