### PR TITLE
Write time.Time out bind parameters back to the destination

### DIFF
--- a/oci8_sql_time_test.go
+++ b/oci8_sql_time_test.go
@@ -909,3 +909,39 @@ func TestDestructiveTimeColumnTypes(t *testing.T) {
 	}
 
 }
+
+// TestExecTimeOutBind tests a time.Time out bind parameter
+func TestExecTimeOutBind(t *testing.T) {
+	if TestDisableDatabase {
+		t.SkipNow()
+	}
+
+	t.Parallel()
+
+	var result time.Time
+	ctx, cancel := context.WithTimeout(context.Background(), TestContextTimeout)
+	defer cancel()
+	_, err := TestDB.ExecContext(ctx, "begin :1 := systimestamp; end;", sql.Out{Dest: &result})
+	if err != nil {
+		t.Fatal("exec error:", err)
+	}
+	if result.IsZero() {
+		t.Fatal("result is zero time")
+	}
+	now := time.Now()
+	if result.Before(now.Add(-time.Hour)) || result.After(now.Add(time.Hour)) {
+		t.Fatal("result time not near now - result:", result, "- now:", now)
+	}
+
+	// a null out value should give a zero time
+	result = time.Unix(1, 0)
+	ctx, cancel = context.WithTimeout(context.Background(), TestContextTimeout)
+	defer cancel()
+	_, err = TestDB.ExecContext(ctx, "begin :1 := cast(null as timestamp with time zone); end;", sql.Out{Dest: &result})
+	if err != nil {
+		t.Fatal("exec error:", err)
+	}
+	if !result.IsZero() {
+		t.Fatal("result is not zero time - result:", result)
+	}
+}

--- a/statement.go
+++ b/statement.go
@@ -886,6 +886,17 @@ func (stmt *Stmt) outputBoundParameters(binds []bindStruct) error {
 					dest.Valid = true
 				}
 
+			case *time.Time:
+				if *bind.indicator == -1 { // the returned value is null
+					*dest = time.Time{}
+					continue
+				}
+				aTime, err := stmt.conn.ociDateTimeToTime(*(**C.OCIDateTime)(bind.pbuf), true)
+				if err != nil {
+					return fmt.Errorf("ociDateTimeToTime for column %v - error: %v", i, err)
+				}
+				*dest = *aTime
+
 			case *bool:
 				buf := (*[1 << 30]byte)(bind.pbuf)[0:1]
 				*dest = buf[0] != 0


### PR DESCRIPTION
sql.Out with a *time.Time destination binds as SQLT_TIMESTAMP_TZ, but outputBoundParameters had no time.Time case, so PL/SQL OUT date/timestamp values were silently dropped and the destination stayed the zero time. The OCIDateTime descriptor is now read back into the destination, with null mapping to the zero time. Adds a test.