### PR TITLE
Default transaction mode to READWRITE so BeginTx skips OCITransStart

### DIFF
--- a/oci8.go
+++ b/oci8.go
@@ -49,11 +49,12 @@ func ParseDSN(dsnString string) (dsn *DSN, err error) {
 	}
 
 	dsn = &DSN{
-		prefetchRows:   0,
-		prefetchMemory: 4096,
-		stmtCacheSize:  0,
-		operationMode:  C.OCI_DEFAULT,
-		timeLocation:   time.UTC,
+		prefetchRows:    0,
+		prefetchMemory:  4096,
+		stmtCacheSize:   0,
+		operationMode:   C.OCI_DEFAULT,
+		transactionMode: C.OCI_TRANS_READWRITE,
+		timeLocation:    time.UTC,
 	}
 
 	authority, dsnString := splitRight(dsnString, "@")

--- a/oci8_test.go
+++ b/oci8_test.go
@@ -216,17 +216,18 @@ func TestParseDSN(t *testing.T) {
 	const prefetchRows = 0
 	const prefetchMemory = 4096
 	const stmtCacheSize = 0
+	const transactionMode = 0x00000200 // C.OCI_TRANS_READWRITE
 
 	var dsnTests = []struct {
 		dsnString   string
 		expectedDSN *DSN
 	}{
-		{"oracle://xxmc:xxmc@107.20.30.169:1521/ORCL?loc=America%2FPhoenix", &DSN{Username: "xxmc", Password: "xxmc", Connect: "107.20.30.169:1521/ORCL", prefetchRows: prefetchRows, prefetchMemory: prefetchMemory, stmtCacheSize: stmtCacheSize, timeLocation: timeLocations[5]}},
-		{"xxmc/xxmc@107.20.30.169:1521/ORCL?loc=America%2FPhoenix", &DSN{Username: "xxmc", Password: "xxmc", Connect: "107.20.30.169:1521/ORCL", prefetchRows: prefetchRows, prefetchMemory: prefetchMemory, stmtCacheSize: stmtCacheSize, timeLocation: timeLocations[5]}},
-		{"sys/syspwd@107.20.30.169:1521/ORCL?loc=America%2FPhoenix&as=sysdba", &DSN{Username: "sys", Password: "syspwd", Connect: "107.20.30.169:1521/ORCL", prefetchRows: prefetchRows, prefetchMemory: prefetchMemory, stmtCacheSize: stmtCacheSize, timeLocation: timeLocations[5], operationMode: 0x00000002}}, // with operationMode: 0x00000002 = C.OCI_SYDBA
-		{"xxmc/xxmc@107.20.30.169:1521/ORCL", &DSN{Username: "xxmc", Password: "xxmc", Connect: "107.20.30.169:1521/ORCL", prefetchRows: prefetchRows, prefetchMemory: prefetchMemory, stmtCacheSize: stmtCacheSize, timeLocation: time.UTC}},
-		{"xxmc/xxmc@107.20.30.169/ORCL", &DSN{Username: "xxmc", Password: "xxmc", Connect: "107.20.30.169/ORCL", prefetchRows: prefetchRows, prefetchMemory: prefetchMemory, stmtCacheSize: stmtCacheSize, timeLocation: time.UTC}},
-		{"xxmc/xxmc@107.20.30.169/ORCL?stmt_cache_size=50", &DSN{Username: "xxmc", Password: "xxmc", Connect: "107.20.30.169/ORCL", prefetchRows: prefetchRows, prefetchMemory: prefetchMemory, stmtCacheSize: 50, timeLocation: time.UTC}},
+		{"oracle://xxmc:xxmc@107.20.30.169:1521/ORCL?loc=America%2FPhoenix", &DSN{Username: "xxmc", Password: "xxmc", Connect: "107.20.30.169:1521/ORCL", prefetchRows: prefetchRows, prefetchMemory: prefetchMemory, stmtCacheSize: stmtCacheSize, transactionMode: transactionMode, timeLocation: timeLocations[5]}},
+		{"xxmc/xxmc@107.20.30.169:1521/ORCL?loc=America%2FPhoenix", &DSN{Username: "xxmc", Password: "xxmc", Connect: "107.20.30.169:1521/ORCL", prefetchRows: prefetchRows, prefetchMemory: prefetchMemory, stmtCacheSize: stmtCacheSize, transactionMode: transactionMode, timeLocation: timeLocations[5]}},
+		{"sys/syspwd@107.20.30.169:1521/ORCL?loc=America%2FPhoenix&as=sysdba", &DSN{Username: "sys", Password: "syspwd", Connect: "107.20.30.169:1521/ORCL", prefetchRows: prefetchRows, prefetchMemory: prefetchMemory, stmtCacheSize: stmtCacheSize, transactionMode: transactionMode, timeLocation: timeLocations[5], operationMode: 0x00000002}}, // with operationMode: 0x00000002 = C.OCI_SYDBA
+		{"xxmc/xxmc@107.20.30.169:1521/ORCL", &DSN{Username: "xxmc", Password: "xxmc", Connect: "107.20.30.169:1521/ORCL", prefetchRows: prefetchRows, prefetchMemory: prefetchMemory, stmtCacheSize: stmtCacheSize, transactionMode: transactionMode, timeLocation: time.UTC}},
+		{"xxmc/xxmc@107.20.30.169/ORCL", &DSN{Username: "xxmc", Password: "xxmc", Connect: "107.20.30.169/ORCL", prefetchRows: prefetchRows, prefetchMemory: prefetchMemory, stmtCacheSize: stmtCacheSize, transactionMode: transactionMode, timeLocation: time.UTC}},
+		{"xxmc/xxmc@107.20.30.169/ORCL?stmt_cache_size=50", &DSN{Username: "xxmc", Password: "xxmc", Connect: "107.20.30.169/ORCL", prefetchRows: prefetchRows, prefetchMemory: prefetchMemory, stmtCacheSize: 50, transactionMode: transactionMode, timeLocation: time.UTC}},
 	}
 
 	for _, tt := range dsnTests {


### PR DESCRIPTION
ParseDSN left transactionMode at its zero value when no isolation parameter was given, so BeginTx always called OCITransStart with an explicit transaction. This made the default behave differently from isolation=DEFAULT and breaks setups where OCITransStart is not allowed, e.g. 19c Transparent Application Continuity reporting ORA-25412 (#437). The default is now OCI_TRANS_READWRITE, same as isolation=DEFAULT.

Fixes #437